### PR TITLE
New neighbourhood records

### DIFF
--- a/data/144/482/771/5/1444827715.geojson
+++ b/data/144/482/771/5/1444827715.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827715,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0198923956,47.7689572907,13.0198923956,47.7689572907",
+    "geom:latitude":47.768957,
+    "geom:longitude":13.019892,
+    "iso:country":"AT",
+    "lbl:latitude":47.768957,
+    "lbl:longitude":13.019892,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Mittemoos"
+    ],
+    "name:eng_x_preferred":[
+        "Mittemoos"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"40f90232aa73cc83ec16cb0fbf6386ca",
+    "wof:hierarchy":[],
+    "wof:id":1444827715,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Mittemoos",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.019892395564797,
+    47.76895729065276,
+    13.019892395564797,
+    47.76895729065276
+],
+  "geometry": {"coordinates":[13.0198923955648,47.76895729065276],"type":"Point"}
+}

--- a/data/144/482/771/5/1444827715.geojson
+++ b/data/144/482/771/5/1444827715.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"40f90232aa73cc83ec16cb0fbf6386ca",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d491250ec236804468d8a07b4fdd0156",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444827715,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827715,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336623,
     "wof:name":"Mittemoos",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.019892395564797,
+    13.0198923955648,
     47.76895729065276,
-    13.019892395564797,
+    13.0198923955648,
     47.76895729065276
 ],
   "geometry": {"coordinates":[13.0198923955648,47.76895729065276],"type":"Point"}

--- a/data/144/482/772/3/1444827723.geojson
+++ b/data/144/482/772/3/1444827723.geojson
@@ -33,15 +33,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"9ae8054e7fc43b58a1eac28438ff0dea",
-    "wof:hierarchy":[],
+    "wof:geomhash":"dd534c8cb2ed1e84a15434e8a013d94c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827723,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827723,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336624,
     "wof:name":"Leopoldskronweiher Siedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -50,9 +67,9 @@
 },
   "bbox": [
     13.03099317019314,
-    47.785568985667254,
+    47.78556898566725,
     13.03099317019314,
-    47.785568985667254
+    47.78556898566725
 ],
   "geometry": {"coordinates":[13.03099317019314,47.78556898566725],"type":"Point"}
 }

--- a/data/144/482/772/3/1444827723.geojson
+++ b/data/144/482/772/3/1444827723.geojson
@@ -1,0 +1,58 @@
+{
+  "id": 1444827723,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0309931702,47.7855689857,13.0309931702,47.7855689857",
+    "geom:latitude":47.785569,
+    "geom:longitude":13.030993,
+    "iso:country":"AT",
+    "lbl:latitude":47.785569,
+    "lbl:longitude":13.030993,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Leopoldskronweiher Siedlung"
+    ],
+    "name:deu_x_variant":[
+        "Leopoldskronweihersiedlung",
+        "Leopoldskron"
+    ],
+    "name:eng_x_preferred":[
+        "Leopoldskronweiher Siedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"9ae8054e7fc43b58a1eac28438ff0dea",
+    "wof:hierarchy":[],
+    "wof:id":1444827723,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Leopoldskronweiher Siedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.03099317019314,
+    47.785568985667254,
+    13.03099317019314,
+    47.785568985667254
+],
+  "geometry": {"coordinates":[13.03099317019314,47.78556898566725],"type":"Point"}
+}

--- a/data/144/482/772/9/1444827729.geojson
+++ b/data/144/482/772/9/1444827729.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"e8f9ee0a0773744509502a396c097e34",
-    "wof:hierarchy":[],
+    "wof:geomhash":"81c180c30b096f18f2cd6b5548000408",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444827729,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827729,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336627,
     "wof:name":"Hammerauersiedlung",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.002669028744531,
+    13.00266902874453,
     47.76434198903013,
-    13.002669028744531,
+    13.00266902874453,
     47.76434198903013
 ],
   "geometry": {"coordinates":[13.00266902874453,47.76434198903013],"type":"Point"}

--- a/data/144/482/772/9/1444827729.geojson
+++ b/data/144/482/772/9/1444827729.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827729,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0026690287,47.764341989,13.0026690287,47.764341989",
+    "geom:latitude":47.764342,
+    "geom:longitude":13.002669,
+    "iso:country":"AT",
+    "lbl:latitude":47.764342,
+    "lbl:longitude":13.002669,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Hammerauersiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Hammerauersiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"e8f9ee0a0773744509502a396c097e34",
+    "wof:hierarchy":[],
+    "wof:id":1444827729,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Hammerauersiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.002669028744531,
+    47.76434198903013,
+    13.002669028744531,
+    47.76434198903013
+],
+  "geometry": {"coordinates":[13.00266902874453,47.76434198903013],"type":"Point"}
+}

--- a/data/144/482/773/7/1444827737.geojson
+++ b/data/144/482/773/7/1444827737.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"d9678b3dadd4795f9581fc890c05880e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e2562079aad3b407744a2353cca942c4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827737,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827737,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336628,
     "wof:name":"Kirchsiedlung Gneis",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.040248584090737,
+    13.04024858409074,
     47.77265885119373,
-    13.040248584090737,
+    13.04024858409074,
     47.77265885119373
 ],
   "geometry": {"coordinates":[13.04024858409074,47.77265885119373],"type":"Point"}

--- a/data/144/482/773/7/1444827737.geojson
+++ b/data/144/482/773/7/1444827737.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827737,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0402485841,47.7726588512,13.0402485841,47.7726588512",
+    "geom:latitude":47.772659,
+    "geom:longitude":13.040249,
+    "iso:country":"AT",
+    "lbl:latitude":47.772659,
+    "lbl:longitude":13.040249,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Kirchsiedlung Gneis"
+    ],
+    "name:eng_x_preferred":[
+        "Kirchsiedlung Gneis"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"d9678b3dadd4795f9581fc890c05880e",
+    "wof:hierarchy":[],
+    "wof:id":1444827737,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Kirchsiedlung Gneis",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.040248584090737,
+    47.77265885119373,
+    13.040248584090737,
+    47.77265885119373
+],
+  "geometry": {"coordinates":[13.04024858409074,47.77265885119373],"type":"Point"}
+}

--- a/data/144/482/774/7/1444827747.geojson
+++ b/data/144/482/774/7/1444827747.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827747,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0356709451,47.778273183,13.0356709451,47.778273183",
+    "geom:latitude":47.778273,
+    "geom:longitude":13.035671,
+    "iso:country":"AT",
+    "lbl:latitude":47.778273,
+    "lbl:longitude":13.035671,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Gneis-Moos"
+    ],
+    "name:eng_x_preferred":[
+        "Gneis-Moos"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"1415c59896d680a5659404b7c7156ee6",
+    "wof:hierarchy":[],
+    "wof:id":1444827747,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Gneis-Moos",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.03567094506874,
+    47.778273182964405,
+    13.03567094506874,
+    47.778273182964405
+],
+  "geometry": {"coordinates":[13.03567094506874,47.7782731829644],"type":"Point"}
+}

--- a/data/144/482/774/7/1444827747.geojson
+++ b/data/144/482/774/7/1444827747.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"1415c59896d680a5659404b7c7156ee6",
-    "wof:hierarchy":[],
+    "wof:geomhash":"fe07b14dff7cb54ae7ff80a1a8f127c5",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827747,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827747,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336631,
     "wof:name":"Gneis-Moos",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -46,9 +63,9 @@
 },
   "bbox": [
     13.03567094506874,
-    47.778273182964405,
+    47.7782731829644,
     13.03567094506874,
-    47.778273182964405
+    47.7782731829644
 ],
   "geometry": {"coordinates":[13.03567094506874,47.7782731829644],"type":"Point"}
 }

--- a/data/144/482/775/1/1444827751.geojson
+++ b/data/144/482/775/1/1444827751.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"6e10d305413fd1c1379927187d53e8cf",
-    "wof:hierarchy":[],
+    "wof:geomhash":"baccd0e4a84e8c460afa65e1acbe8a0e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827751,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827751,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336631,
     "wof:name":"Thumegg",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.045169546039386,
+    13.04516954603939,
     47.7838100122871,
-    13.045169546039386,
+    13.04516954603939,
     47.7838100122871
 ],
   "geometry": {"coordinates":[13.04516954603939,47.7838100122871],"type":"Point"}

--- a/data/144/482/775/1/1444827751.geojson
+++ b/data/144/482/775/1/1444827751.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827751,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.045169546,47.7838100123,13.045169546,47.7838100123",
+    "geom:latitude":47.78381,
+    "geom:longitude":13.04517,
+    "iso:country":"AT",
+    "lbl:latitude":47.78381,
+    "lbl:longitude":13.04517,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Thumegg"
+    ],
+    "name:eng_x_preferred":[
+        "Thumegg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"6e10d305413fd1c1379927187d53e8cf",
+    "wof:hierarchy":[],
+    "wof:id":1444827751,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Thumegg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.045169546039386,
+    47.7838100122871,
+    13.045169546039386,
+    47.7838100122871
+],
+  "geometry": {"coordinates":[13.04516954603939,47.7838100122871],"type":"Point"}
+}

--- a/data/144/482/775/9/1444827759.geojson
+++ b/data/144/482/775/9/1444827759.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"3e742a7189ce381f84263f4232ae68b9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c38a08d19ede82ae03a8c2e71cd8b2cb",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827759,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827759,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336632,
     "wof:name":"Leopoldskroner Weiher",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.039104174335236,
+    13.03910417433524,
     47.78911558704414,
-    13.039104174335236,
+    13.03910417433524,
     47.78911558704414
 ],
   "geometry": {"coordinates":[13.03910417433524,47.78911558704414],"type":"Point"}

--- a/data/144/482/775/9/1444827759.geojson
+++ b/data/144/482/775/9/1444827759.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827759,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0391041743,47.789115587,13.0391041743,47.789115587",
+    "geom:latitude":47.789116,
+    "geom:longitude":13.039104,
+    "iso:country":"AT",
+    "lbl:latitude":47.789116,
+    "lbl:longitude":13.039104,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Leopoldskroner Weiher"
+    ],
+    "name:eng_x_preferred":[
+        "Leopoldskroner Weiher"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"3e742a7189ce381f84263f4232ae68b9",
+    "wof:hierarchy":[],
+    "wof:id":1444827759,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Leopoldskroner Weiher",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.039104174335236,
+    47.78911558704414,
+    13.039104174335236,
+    47.78911558704414
+],
+  "geometry": {"coordinates":[13.03910417433524,47.78911558704414],"type":"Point"}
+}

--- a/data/144/482/776/7/1444827767.geojson
+++ b/data/144/482/776/7/1444827767.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444827767,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.028976148,47.792383244,13.028976148,47.792383244",
+    "geom:latitude":47.792383,
+    "geom:longitude":13.028976,
+    "iso:country":"AT",
+    "lbl:latitude":47.792383,
+    "lbl:longitude":13.028976,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Riedenburg-St Paul"
+    ],
+    "name:deu_x_variant":[
+        "Riedenburg-Sankt Paul"
+    ],
+    "name:eng_x_preferred":[
+        "Riedenburg-St Paul"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"d70854681f72bc06ea8a7abe71b7c6de",
+    "wof:hierarchy":[],
+    "wof:id":1444827767,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Riedenburg-St Paul",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.02897614799907,
+    47.792383244009415,
+    13.02897614799907,
+    47.792383244009415
+],
+  "geometry": {"coordinates":[13.02897614799907,47.79238324400941],"type":"Point"}
+}

--- a/data/144/482/776/7/1444827767.geojson
+++ b/data/144/482/776/7/1444827767.geojson
@@ -32,15 +32,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"d70854681f72bc06ea8a7abe71b7c6de",
-    "wof:hierarchy":[],
+    "wof:geomhash":"770aef5bee7d1f50bbc105d47e599ae4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827767,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827767,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336635,
     "wof:name":"Riedenburg-St Paul",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -49,9 +66,9 @@
 },
   "bbox": [
     13.02897614799907,
-    47.792383244009415,
+    47.79238324400941,
     13.02897614799907,
-    47.792383244009415
+    47.79238324400941
 ],
   "geometry": {"coordinates":[13.02897614799907,47.79238324400941],"type":"Point"}
 }

--- a/data/144/482/778/1/1444827781.geojson
+++ b/data/144/482/778/1/1444827781.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"6845db52d91054657c05f557ee4680bd",
-    "wof:hierarchy":[],
+    "wof:geomhash":"0f2d9dd3210652742612c69decefacf6",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827781,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827781,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336636,
     "wof:name":"Aeussere Riedenburg",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.029205029950168,
+    13.02920502995017,
     47.79776481936432,
-    13.029205029950168,
+    13.02920502995017,
     47.79776481936432
 ],
   "geometry": {"coordinates":[13.02920502995017,47.79776481936432],"type":"Point"}

--- a/data/144/482/778/1/1444827781.geojson
+++ b/data/144/482/778/1/1444827781.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827781,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.02920503,47.7977648194,13.02920503,47.7977648194",
+    "geom:latitude":47.797765,
+    "geom:longitude":13.029205,
+    "iso:country":"AT",
+    "lbl:latitude":47.797765,
+    "lbl:longitude":13.029205,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "\u00c4u\u00dfere Riedenburg"
+    ],
+    "name:eng_x_preferred":[
+        "Aeussere Riedenburg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"6845db52d91054657c05f557ee4680bd",
+    "wof:hierarchy":[],
+    "wof:id":1444827781,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Aeussere Riedenburg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.029205029950168,
+    47.79776481936432,
+    13.029205029950168,
+    47.79776481936432
+],
+  "geometry": {"coordinates":[13.02920502995017,47.79776481936432],"type":"Point"}
+}

--- a/data/144/482/778/5/1444827785.geojson
+++ b/data/144/482/778/5/1444827785.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"3e2d12ec008211c031a784baba3f5b18",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827785,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827785,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336638,
     "wof:name":"Innere Riedenburg",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/482/778/5/1444827785.geojson
+++ b/data/144/482/778/5/1444827785.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827785,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0353276221,47.7974957538,13.0353276221,47.7974957538",
+    "geom:latitude":47.797496,
+    "geom:longitude":13.035328,
+    "iso:country":"AT",
+    "lbl:latitude":47.797496,
+    "lbl:longitude":13.035328,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Innere Riedenburg"
+    ],
+    "name:eng_x_preferred":[
+        "Innere Riedenburg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"3e2d12ec008211c031a784baba3f5b18",
+    "wof:hierarchy":[],
+    "wof:id":1444827785,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Innere Riedenburg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.03532762214209,
+    47.79749575383385,
+    13.03532762214209,
+    47.79749575383385
+],
+  "geometry": {"coordinates":[13.03532762214209,47.79749575383385],"type":"Point"}
+}

--- a/data/144/482/779/5/1444827795.geojson
+++ b/data/144/482/779/5/1444827795.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827795,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0300919475,47.7903650096,13.0300919475,47.7903650096",
+    "geom:latitude":47.790365,
+    "geom:longitude":13.030092,
+    "iso:country":"AT",
+    "lbl:latitude":47.790365,
+    "lbl:longitude":13.030092,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Rosittensiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Rosittensiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"2ccfdf6428347d760594ea3f7b4e98b8",
+    "wof:hierarchy":[],
+    "wof:id":1444827795,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Rosittensiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.030091947510682,
+    47.79036500955603,
+    13.030091947510682,
+    47.79036500955603
+],
+  "geometry": {"coordinates":[13.03009194751068,47.79036500955603],"type":"Point"}
+}

--- a/data/144/482/779/5/1444827795.geojson
+++ b/data/144/482/779/5/1444827795.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"2ccfdf6428347d760594ea3f7b4e98b8",
-    "wof:hierarchy":[],
+    "wof:geomhash":"430fcc418317d8f3d63d4c8915984f6e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827795,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827795,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336638,
     "wof:name":"Rosittensiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.030091947510682,
+    13.03009194751068,
     47.79036500955603,
-    13.030091947510682,
+    13.03009194751068,
     47.79036500955603
 ],
   "geometry": {"coordinates":[13.03009194751068,47.79036500955603],"type":"Point"}

--- a/data/144/482/780/9/1444827809.geojson
+++ b/data/144/482/780/9/1444827809.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827809,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0260865134,47.7912588088,13.0260865134,47.7912588088",
+    "geom:latitude":47.791259,
+    "geom:longitude":13.026087,
+    "iso:country":"AT",
+    "lbl:latitude":47.791259,
+    "lbl:longitude":13.026086,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Lanserhofsiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Lanserhofsiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"cfbf894328f7d4ee99a14d0fedb6f455",
+    "wof:hierarchy":[],
+    "wof:id":1444827809,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Lanserhofsiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.02608651336643,
+    47.79125880876917,
+    13.02608651336643,
+    47.79125880876917
+],
+  "geometry": {"coordinates":[13.02608651336643,47.79125880876917],"type":"Point"}
+}

--- a/data/144/482/780/9/1444827809.geojson
+++ b/data/144/482/780/9/1444827809.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"cfbf894328f7d4ee99a14d0fedb6f455",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827809,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827809,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336639,
     "wof:name":"Lanserhofsiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/482/781/7/1444827817.geojson
+++ b/data/144/482/781/7/1444827817.geojson
@@ -32,15 +32,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"436db2a57d8b3ec6369324421c12cb8e",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827817,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827817,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336642,
     "wof:name":"Schliesselbergersiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/482/781/7/1444827817.geojson
+++ b/data/144/482/781/7/1444827817.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444827817,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0231682685,47.7924024649,13.0231682685,47.7924024649",
+    "geom:latitude":47.792402,
+    "geom:longitude":13.023168,
+    "iso:country":"AT",
+    "lbl:latitude":47.792402,
+    "lbl:longitude":13.023168,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Schliesselbergersiedlung"
+    ],
+    "name:deu_x_variant":[
+        "Schliesselberger Siedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Schliesselbergersiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"436db2a57d8b3ec6369324421c12cb8e",
+    "wof:hierarchy":[],
+    "wof:id":1444827817,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Schliesselbergersiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.02316826848991,
+    47.79240246491311,
+    13.02316826848991,
+    47.79240246491311
+],
+  "geometry": {"coordinates":[13.02316826848991,47.79240246491311],"type":"Point"}
+}

--- a/data/144/482/782/1/1444827821.geojson
+++ b/data/144/482/782/1/1444827821.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827821,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0438534748,47.798975597,13.0438534748,47.798975597",
+    "geom:latitude":47.798976,
+    "geom:longitude":13.043853,
+    "iso:country":"AT",
+    "lbl:latitude":47.798975,
+    "lbl:longitude":13.043853,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Linke Altstadt"
+    ],
+    "name:eng_x_preferred":[
+        "Linke Altstadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"85a6d641c0ed24302cb15efc69fa9cc8",
+    "wof:hierarchy":[],
+    "wof:id":1444827821,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Linke Altstadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.043853474820562,
+    47.798975597008244,
+    13.043853474820562,
+    47.798975597008244
+],
+  "geometry": {"coordinates":[13.04385347482056,47.79897559700824],"type":"Point"}
+}

--- a/data/144/482/782/1/1444827821.geojson
+++ b/data/144/482/782/1/1444827821.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"85a6d641c0ed24302cb15efc69fa9cc8",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e686d62b76fd6ebe0d98ae4375ebed59",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827821,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827821,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336643,
     "wof:name":"Linke Altstadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.043853474820562,
-    47.798975597008244,
-    13.043853474820562,
-    47.798975597008244
+    13.04385347482056,
+    47.79897559700824,
+    13.04385347482056,
+    47.79897559700824
 ],
   "geometry": {"coordinates":[13.04385347482056,47.79897559700824],"type":"Point"}
 }

--- a/data/144/482/783/1/1444827831.geojson
+++ b/data/144/482/783/1/1444827831.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827831,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0436818134,47.8036262583,13.0436818134,47.8036262583",
+    "geom:latitude":47.803626,
+    "geom:longitude":13.043682,
+    "iso:country":"AT",
+    "lbl:latitude":47.803626,
+    "lbl:longitude":13.043682,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Rechte Altstadt"
+    ],
+    "name:eng_x_preferred":[
+        "Rechte Altstadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"c9ffa8f9fa9ce78dc74a15099de14fc2",
+    "wof:hierarchy":[],
+    "wof:id":1444827831,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Rechte Altstadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.043681813357237,
+    47.803626258296305,
+    13.043681813357237,
+    47.803626258296305
+],
+  "geometry": {"coordinates":[13.04368181335724,47.8036262582963],"type":"Point"}
+}

--- a/data/144/482/783/1/1444827831.geojson
+++ b/data/144/482/783/1/1444827831.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"c9ffa8f9fa9ce78dc74a15099de14fc2",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c9abcc570ae3158c83b5cb3f4e56b48a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827831,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827831,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336644,
     "wof:name":"Rechte Altstadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.043681813357237,
-    47.803626258296305,
-    13.043681813357237,
-    47.803626258296305
+    13.04368181335724,
+    47.8036262582963,
+    13.04368181335724,
+    47.8036262582963
 ],
   "geometry": {"coordinates":[13.04368181335724,47.8036262582963],"type":"Point"}
 }

--- a/data/144/482/784/5/1444827845.geojson
+++ b/data/144/482/784/5/1444827845.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827845,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0512492229,47.7973804396,13.0512492229,47.7973804396",
+    "geom:latitude":47.79738,
+    "geom:longitude":13.051249,
+    "iso:country":"AT",
+    "lbl:latitude":47.79738,
+    "lbl:longitude":13.051249,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Kaiviertel"
+    ],
+    "name:eng_x_preferred":[
+        "Kaiviertel"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"a9aacc5e622065456d9aa06d566b94e7",
+    "wof:hierarchy":[],
+    "wof:id":1444827845,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Kaiviertel",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.051249222865478,
+    47.79738043960851,
+    13.051249222865478,
+    47.79738043960851
+],
+  "geometry": {"coordinates":[13.05124922286548,47.79738043960851],"type":"Point"}
+}

--- a/data/144/482/784/5/1444827845.geojson
+++ b/data/144/482/784/5/1444827845.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"a9aacc5e622065456d9aa06d566b94e7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a7e3ab1c88a92a1ef8818183c91215bc",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827845,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827845,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336646,
     "wof:name":"Kaiviertel",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.051249222865478,
+    13.05124922286548,
     47.79738043960851,
-    13.051249222865478,
+    13.05124922286548,
     47.79738043960851
 ],
   "geometry": {"coordinates":[13.05124922286548,47.79738043960851],"type":"Point"}

--- a/data/144/482/785/3/1444827853.geojson
+++ b/data/144/482/785/3/1444827853.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827853,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0498759312,47.8005899233,13.0498759312,47.8005899233",
+    "geom:latitude":47.80059,
+    "geom:longitude":13.049876,
+    "iso:country":"AT",
+    "lbl:latitude":47.80059,
+    "lbl:longitude":13.049876,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Inneres Stein"
+    ],
+    "name:eng_x_preferred":[
+        "Inneres Stein"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"9620de01585043536adc69d35f726f88",
+    "wof:hierarchy":[],
+    "wof:id":1444827853,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Inneres Stein",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.049875931158878,
+    47.80058992330863,
+    13.049875931158878,
+    47.80058992330863
+],
+  "geometry": {"coordinates":[13.04987593115888,47.80058992330863],"type":"Point"}
+}

--- a/data/144/482/785/3/1444827853.geojson
+++ b/data/144/482/785/3/1444827853.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"9620de01585043536adc69d35f726f88",
-    "wof:hierarchy":[],
+    "wof:geomhash":"28178dc4a4d76bd71258a56b6666378b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827853,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827853,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336646,
     "wof:name":"Inneres Stein",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.049875931158878,
+    13.04987593115888,
     47.80058992330863,
-    13.049875931158878,
+    13.04987593115888,
     47.80058992330863
 ],
   "geometry": {"coordinates":[13.04987593115888,47.80058992330863],"type":"Point"}

--- a/data/144/482/785/9/1444827859.geojson
+++ b/data/144/482/785/9/1444827859.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"f112737dca3d72b6d3ab8e3cd4c3e2fc",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9146b249af19c8cc31e48699bf66b012",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827859,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827859,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336647,
     "wof:name":"Aeusserer Stein",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -46,9 +63,9 @@
 },
   "bbox": [
     13.05471106237586,
-    47.799513711348546,
+    47.79951371134855,
     13.05471106237586,
-    47.799513711348546
+    47.79951371134855
 ],
   "geometry": {"coordinates":[13.05471106237586,47.79951371134855],"type":"Point"}
 }

--- a/data/144/482/785/9/1444827859.geojson
+++ b/data/144/482/785/9/1444827859.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827859,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0547110624,47.7995137113,13.0547110624,47.7995137113",
+    "geom:latitude":47.799514,
+    "geom:longitude":13.054711,
+    "iso:country":"AT",
+    "lbl:latitude":47.799514,
+    "lbl:longitude":13.054711,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "\u00c4u\u00dferer Stein"
+    ],
+    "name:eng_x_preferred":[
+        "Aeusserer Stein"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"f112737dca3d72b6d3ab8e3cd4c3e2fc",
+    "wof:hierarchy":[],
+    "wof:id":1444827859,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Aeusserer Stein",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.05471106237586,
+    47.799513711348546,
+    13.05471106237586,
+    47.799513711348546
+],
+  "geometry": {"coordinates":[13.05471106237586,47.79951371134855],"type":"Point"}
+}

--- a/data/144/482/786/9/1444827869.geojson
+++ b/data/144/482/786/9/1444827869.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827869,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0305640165,47.8031266204,13.0305640165,47.8031266204",
+    "geom:latitude":47.803127,
+    "geom:longitude":13.030564,
+    "iso:country":"AT",
+    "lbl:latitude":47.803127,
+    "lbl:longitude":13.030564,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "\u00c4u\u00dferer Muelln"
+    ],
+    "name:eng_x_preferred":[
+        "Aeusserer M\u00fclln"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"d04261829324ed6b5123504390525c11",
+    "wof:hierarchy":[],
+    "wof:id":1444827869,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Aeusserer M\u00fclln",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.030564016534827,
+    47.8031266204341,
+    13.030564016534827,
+    47.8031266204341
+],
+  "geometry": {"coordinates":[13.03056401653483,47.8031266204341],"type":"Point"}
+}

--- a/data/144/482/786/9/1444827869.geojson
+++ b/data/144/482/786/9/1444827869.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"d04261829324ed6b5123504390525c11",
-    "wof:hierarchy":[],
+    "wof:geomhash":"30e38a719c4844952dca597c3e543a34",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827869,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827869,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336650,
     "wof:name":"Aeusserer M\u00fclln",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.030564016534827,
+    13.03056401653483,
     47.8031266204341,
-    13.030564016534827,
+    13.03056401653483,
     47.8031266204341
 ],
   "geometry": {"coordinates":[13.03056401653483,47.8031266204341],"type":"Point"}

--- a/data/144/482/788/1/1444827881.geojson
+++ b/data/144/482/788/1/1444827881.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827881,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0350844351,47.8062012388,13.0350844351,47.8062012388",
+    "geom:latitude":47.806201,
+    "geom:longitude":13.035084,
+    "iso:country":"AT",
+    "lbl:latitude":47.806201,
+    "lbl:longitude":13.035084,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Inneres M\u00fclln"
+    ],
+    "name:eng_x_preferred":[
+        "Inneres Muelln"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"9ccea6d0276b236a4c55e0489e316f77",
+    "wof:hierarchy":[],
+    "wof:id":1444827881,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Inneres Muelln",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.03508443506905,
+    47.80620123876259,
+    13.03508443506905,
+    47.80620123876259
+],
+  "geometry": {"coordinates":[13.03508443506905,47.80620123876259],"type":"Point"}
+}

--- a/data/144/482/788/1/1444827881.geojson
+++ b/data/144/482/788/1/1444827881.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"9ccea6d0276b236a4c55e0489e316f77",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827881,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827881,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336651,
     "wof:name":"Inneres Muelln",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/482/789/1/1444827891.geojson
+++ b/data/144/482/789/1/1444827891.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827891,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0133978702,47.8034148736,13.0133978702,47.8034148736",
+    "geom:latitude":47.803415,
+    "geom:longitude":13.013398,
+    "iso:country":"AT",
+    "lbl:latitude":47.803415,
+    "lbl:longitude":13.013398,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Altmaxglan"
+    ],
+    "name:eng_x_preferred":[
+        "Altmaxglan"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"874ee50341169b4f13aa142b8664dd22",
+    "wof:hierarchy":[],
+    "wof:id":1444827891,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Altmaxglan",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.013397870202336,
+    47.803414873633415,
+    13.013397870202336,
+    47.803414873633415
+],
+  "geometry": {"coordinates":[13.01339787020234,47.80341487363341],"type":"Point"}
+}

--- a/data/144/482/789/1/1444827891.geojson
+++ b/data/144/482/789/1/1444827891.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"874ee50341169b4f13aa142b8664dd22",
-    "wof:hierarchy":[],
+    "wof:geomhash":"fb4574f7ffc9e5a4ca2469c6b5634481",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827891,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827891,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336652,
     "wof:name":"Altmaxglan",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.013397870202336,
-    47.803414873633415,
-    13.013397870202336,
-    47.803414873633415
+    13.01339787020234,
+    47.80341487363341,
+    13.01339787020234,
+    47.80341487363341
 ],
   "geometry": {"coordinates":[13.01339787020234,47.80341487363341],"type":"Point"}
 }

--- a/data/144/482/790/3/1444827903.geojson
+++ b/data/144/482/790/3/1444827903.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"ee6af217d64ab3e6ca84d4f5d9dfdd6c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d64697751949dcf177b89e4721c9deba",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827903,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827903,
-    "wof:lastmodified":1566333177,
+    "wof:lastmodified":1566336652,
     "wof:name":"Neumaxglan",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.024498644830679,
-    47.800878190583816,
-    13.024498644830679,
-    47.800878190583816
+    13.02449864483068,
+    47.80087819058382,
+    13.02449864483068,
+    47.80087819058382
 ],
   "geometry": {"coordinates":[13.02449864483068,47.80087819058382],"type":"Point"}
 }

--- a/data/144/482/790/3/1444827903.geojson
+++ b/data/144/482/790/3/1444827903.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827903,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0244986448,47.8008781906,13.0244986448,47.8008781906",
+    "geom:latitude":47.800878,
+    "geom:longitude":13.024499,
+    "iso:country":"AT",
+    "lbl:latitude":47.800878,
+    "lbl:longitude":13.024499,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Neumaxglan"
+    ],
+    "name:eng_x_preferred":[
+        "Neumaxglan"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"ee6af217d64ab3e6ca84d4f5d9dfdd6c",
+    "wof:hierarchy":[],
+    "wof:id":1444827903,
+    "wof:lastmodified":1566333177,
+    "wof:name":"Neumaxglan",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.024498644830679,
+    47.800878190583816,
+    13.024498644830679,
+    47.800878190583816
+],
+  "geometry": {"coordinates":[13.02449864483068,47.80087819058382],"type":"Point"}
+}

--- a/data/144/482/791/3/1444827913.geojson
+++ b/data/144/482/791/3/1444827913.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"c635b63e8bc2d5f939a9fa2d1a03aa52",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6d700a472ca403020c9b1ce7fe410f1e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827913,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827913,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336655,
     "wof:name":"Glanhofen",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.004814797036088,
+    13.00481479703609,
     47.79914856293976,
-    13.004814797036088,
+    13.00481479703609,
     47.79914856293976
 ],
   "geometry": {"coordinates":[13.00481479703609,47.79914856293976],"type":"Point"}

--- a/data/144/482/791/3/1444827913.geojson
+++ b/data/144/482/791/3/1444827913.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827913,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.004814797,47.7991485629,13.004814797,47.7991485629",
+    "geom:latitude":47.799149,
+    "geom:longitude":13.004815,
+    "iso:country":"AT",
+    "lbl:latitude":47.799149,
+    "lbl:longitude":13.004815,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Glanhofen"
+    ],
+    "name:eng_x_preferred":[
+        "Glanhofen"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"c635b63e8bc2d5f939a9fa2d1a03aa52",
+    "wof:hierarchy":[],
+    "wof:id":1444827913,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Glanhofen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.004814797036088,
+    47.79914856293976,
+    13.004814797036088,
+    47.79914856293976
+],
+  "geometry": {"coordinates":[13.00481479703609,47.79914856293976],"type":"Point"}
+}

--- a/data/144/482/792/5/1444827925.geojson
+++ b/data/144/482/792/5/1444827925.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827925,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0175177453,47.7931136334,13.0175177453,47.7931136334",
+    "geom:latitude":47.793114,
+    "geom:longitude":13.017518,
+    "iso:country":"AT",
+    "lbl:latitude":47.793114,
+    "lbl:longitude":13.017518,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Maxglan-Riedenburg"
+    ],
+    "name:eng_x_preferred":[
+        "Maxglan-Riedenburg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"5a51cd026c250af88c278331098d2151",
+    "wof:hierarchy":[],
+    "wof:id":1444827925,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Maxglan-Riedenburg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.017517745322134,
+    47.79311363335284,
+    13.017517745322134,
+    47.79311363335284
+],
+  "geometry": {"coordinates":[13.01751774532213,47.79311363335284],"type":"Point"}
+}

--- a/data/144/482/792/5/1444827925.geojson
+++ b/data/144/482/792/5/1444827925.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"5a51cd026c250af88c278331098d2151",
-    "wof:hierarchy":[],
+    "wof:geomhash":"0211dc0e20c0cd19e3b73422124c7bdd",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827925,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827925,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336656,
     "wof:name":"Maxglan-Riedenburg",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.017517745322134,
+    13.01751774532213,
     47.79311363335284,
-    13.017517745322134,
+    13.01751774532213,
     47.79311363335284
 ],
   "geometry": {"coordinates":[13.01751774532213,47.79311363335284],"type":"Point"}

--- a/data/144/482/793/7/1444827937.geojson
+++ b/data/144/482/793/7/1444827937.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"29a27bb17d7456a66a784897b761648e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"551bced28d8c1d121df8bd8dadc6d3eb",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827937,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827937,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336657,
     "wof:name":"Burgfried",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.019863785320906,
-    47.805182791598725,
-    13.019863785320906,
-    47.805182791598725
+    13.01986378532091,
+    47.80518279159872,
+    13.01986378532091,
+    47.80518279159872
 ],
   "geometry": {"coordinates":[13.01986378532091,47.80518279159872],"type":"Point"}
 }

--- a/data/144/482/793/7/1444827937.geojson
+++ b/data/144/482/793/7/1444827937.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827937,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0198637853,47.8051827916,13.0198637853,47.8051827916",
+    "geom:latitude":47.805183,
+    "geom:longitude":13.019864,
+    "iso:country":"AT",
+    "lbl:latitude":47.805183,
+    "lbl:longitude":13.019864,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Burgfried"
+    ],
+    "name:eng_x_preferred":[
+        "Burgfried"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"29a27bb17d7456a66a784897b761648e",
+    "wof:hierarchy":[],
+    "wof:id":1444827937,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Burgfried",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.019863785320906,
+    47.805182791598725,
+    13.019863785320906,
+    47.805182791598725
+],
+  "geometry": {"coordinates":[13.01986378532091,47.80518279159872],"type":"Point"}
+}

--- a/data/144/482/794/7/1444827947.geojson
+++ b/data/144/482/794/7/1444827947.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827947,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0179182887,47.8042027576,13.0179182887,47.8042027576",
+    "geom:latitude":47.804203,
+    "geom:longitude":13.017918,
+    "iso:country":"AT",
+    "lbl:latitude":47.804203,
+    "lbl:longitude":13.017918,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Kirchenviertel Maxglan"
+    ],
+    "name:eng_x_preferred":[
+        "Kirchenviertel Maxglan"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"fc69e6f9c22a6fda935331945f2bbe33",
+    "wof:hierarchy":[],
+    "wof:id":1444827947,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Kirchenviertel Maxglan",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.017918288736556,
+    47.80420275755038,
+    13.017918288736556,
+    47.80420275755038
+],
+  "geometry": {"coordinates":[13.01791828873656,47.80420275755038],"type":"Point"}
+}

--- a/data/144/482/794/7/1444827947.geojson
+++ b/data/144/482/794/7/1444827947.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"fc69e6f9c22a6fda935331945f2bbe33",
-    "wof:hierarchy":[],
+    "wof:geomhash":"173ca90fd697272cb49782020c472918",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827947,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827947,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336657,
     "wof:name":"Kirchenviertel Maxglan",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.017918288736556,
+    13.01791828873656,
     47.80420275755038,
-    13.017918288736556,
+    13.01791828873656,
     47.80420275755038
 ],
   "geometry": {"coordinates":[13.01791828873656,47.80420275755038],"type":"Point"}

--- a/data/144/482/795/9/1444827959.geojson
+++ b/data/144/482/795/9/1444827959.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444827959,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0276743819,47.8157313991,13.0276743819,47.8157313991",
+    "geom:latitude":47.815731,
+    "geom:longitude":13.027674,
+    "iso:country":"AT",
+    "lbl:latitude":47.815731,
+    "lbl:longitude":13.027674,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Scherzhauserfeld Siedlung"
+    ],
+    "name:deu_x_variant":[
+        "Scherzhauserfeldsiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Scherzhauserfeld Siedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"8ac177e4d7e6c42d6cdb6cd46f1694ae",
+    "wof:hierarchy":[],
+    "wof:id":1444827959,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Scherzhauserfeld Siedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.027674381902187,
+    47.815731399053604,
+    13.027674381902187,
+    47.815731399053604
+],
+  "geometry": {"coordinates":[13.02767438190219,47.8157313990536],"type":"Point"}
+}

--- a/data/144/482/795/9/1444827959.geojson
+++ b/data/144/482/795/9/1444827959.geojson
@@ -32,15 +32,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"8ac177e4d7e6c42d6cdb6cd46f1694ae",
-    "wof:hierarchy":[],
+    "wof:geomhash":"bc09fc8d67e6c7b1fea3201700632d47",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827959,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827959,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336660,
     "wof:name":"Scherzhauserfeld Siedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -48,10 +65,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.027674381902187,
-    47.815731399053604,
-    13.027674381902187,
-    47.815731399053604
+    13.02767438190219,
+    47.8157313990536,
+    13.02767438190219,
+    47.8157313990536
 ],
   "geometry": {"coordinates":[13.02767438190219,47.8157313990536],"type":"Point"}
 }

--- a/data/144/482/797/1/1444827971.geojson
+++ b/data/144/482/797/1/1444827971.geojson
@@ -32,15 +32,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"0d8c7bd863793f30f18a7ea0b43ca56b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8a1bbac1588122126ce02824ab845d8a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827971,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827971,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336661,
     "wof:name":"Annahof Siedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -48,9 +65,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.020321549223102,
+    13.0203215492231,
     47.81067832622568,
-    13.020321549223102,
+    13.0203215492231,
     47.81067832622568
 ],
   "geometry": {"coordinates":[13.0203215492231,47.81067832622568],"type":"Point"}

--- a/data/144/482/797/1/1444827971.geojson
+++ b/data/144/482/797/1/1444827971.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444827971,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0203215492,47.8106783262,13.0203215492,47.8106783262",
+    "geom:latitude":47.810678,
+    "geom:longitude":13.020322,
+    "iso:country":"AT",
+    "lbl:latitude":47.810678,
+    "lbl:longitude":13.020321,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Annahof Siedlung"
+    ],
+    "name:deu_x_variant":[
+        "Annahofsiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Annahof Siedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"0d8c7bd863793f30f18a7ea0b43ca56b",
+    "wof:hierarchy":[],
+    "wof:id":1444827971,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Annahof Siedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.020321549223102,
+    47.81067832622568,
+    13.020321549223102,
+    47.81067832622568
+],
+  "geometry": {"coordinates":[13.0203215492231,47.81067832622568],"type":"Point"}
+}

--- a/data/144/482/798/1/1444827981.geojson
+++ b/data/144/482/798/1/1444827981.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"4eedbaa9a81e4b686a46d3c1bfbf96c3",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ad9ee0e5841510d56b6b757a4efff1f1",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827981,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827981,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336662,
     "wof:name":"General-Keyes-Siedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.023068132636304,
+    13.0230681326363,
     47.8149629025718,
-    13.023068132636304,
+    13.0230681326363,
     47.8149629025718
 ],
   "geometry": {"coordinates":[13.0230681326363,47.8149629025718],"type":"Point"}

--- a/data/144/482/798/1/1444827981.geojson
+++ b/data/144/482/798/1/1444827981.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827981,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0230681326,47.8149629026,13.0230681326,47.8149629026",
+    "geom:latitude":47.814963,
+    "geom:longitude":13.023068,
+    "iso:country":"AT",
+    "lbl:latitude":47.814963,
+    "lbl:longitude":13.023068,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "General-Keyes-Siedlung"
+    ],
+    "name:eng_x_preferred":[
+        "General-Keyes-Siedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"4eedbaa9a81e4b686a46d3c1bfbf96c3",
+    "wof:hierarchy":[],
+    "wof:id":1444827981,
+    "wof:lastmodified":1566333178,
+    "wof:name":"General-Keyes-Siedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.023068132636304,
+    47.8149629025718,
+    13.023068132636304,
+    47.8149629025718
+],
+  "geometry": {"coordinates":[13.0230681326363,47.8149629025718],"type":"Point"}
+}

--- a/data/144/482/799/3/1444827993.geojson
+++ b/data/144/482/799/3/1444827993.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444827993,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0166022175,47.8172875696,13.0166022175,47.8172875696",
+    "geom:latitude":47.817288,
+    "geom:longitude":13.016602,
+    "iso:country":"AT",
+    "lbl:latitude":47.817287,
+    "lbl:longitude":13.016602,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Liefering-S\u00fcd"
+    ],
+    "name:eng_x_preferred":[
+        "Liefering-Sued"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"0fb0c19d8b82c6a0f7adfc5474ae9ab7",
+    "wof:hierarchy":[],
+    "wof:id":1444827993,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Liefering-Sued",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.01660221751773,
+    47.817287569593184,
+    13.01660221751773,
+    47.817287569593184
+],
+  "geometry": {"coordinates":[13.01660221751773,47.81728756959318],"type":"Point"}
+}

--- a/data/144/482/799/3/1444827993.geojson
+++ b/data/144/482/799/3/1444827993.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"0fb0c19d8b82c6a0f7adfc5474ae9ab7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"cab76271a019412831087502b25056fa",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444827993,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444827993,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336665,
     "wof:name":"Liefering-Sued",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -46,9 +63,9 @@
 },
   "bbox": [
     13.01660221751773,
-    47.817287569593184,
+    47.81728756959318,
     13.01660221751773,
-    47.817287569593184
+    47.81728756959318
 ],
   "geometry": {"coordinates":[13.01660221751773,47.81728756959318],"type":"Point"}
 }

--- a/data/144/482/800/3/1444828003.geojson
+++ b/data/144/482/800/3/1444828003.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828003,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0235258965,47.8191702815,13.0235258965,47.8191702815",
+    "geom:latitude":47.81917,
+    "geom:longitude":13.023526,
+    "iso:country":"AT",
+    "lbl:latitude":47.81917,
+    "lbl:longitude":13.023526,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Liefering-Lehenau"
+    ],
+    "name:eng_x_preferred":[
+        "Liefering-Lehenau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"530cad4193b749195ba2430777703d13",
+    "wof:hierarchy":[],
+    "wof:id":1444828003,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Liefering-Lehenau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.023525896538501,
+    47.8191702814763,
+    13.023525896538501,
+    47.8191702814763
+],
+  "geometry": {"coordinates":[13.0235258965385,47.8191702814763],"type":"Point"}
+}

--- a/data/144/482/800/3/1444828003.geojson
+++ b/data/144/482/800/3/1444828003.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"530cad4193b749195ba2430777703d13",
-    "wof:hierarchy":[],
+    "wof:geomhash":"64d52b4cb6bc39e4a6e55de1e3cd3834",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828003,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828003,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336665,
     "wof:name":"Liefering-Lehenau",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.023525896538501,
+    13.0235258965385,
     47.8191702814763,
-    13.023525896538501,
+    13.0235258965385,
     47.8191702814763
 ],
   "geometry": {"coordinates":[13.0235258965385,47.8191702814763],"type":"Point"}

--- a/data/144/482/801/1/1444828011.geojson
+++ b/data/144/482/801/1/1444828011.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828011,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.009621318,47.824472246,13.009621318,47.824472246",
+    "geom:latitude":47.824472,
+    "geom:longitude":13.009621,
+    "iso:country":"AT",
+    "lbl:latitude":47.824472,
+    "lbl:longitude":13.009621,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Altliefering"
+    ],
+    "name:eng_x_preferred":[
+        "Altliefering"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"5e94aba5dc44bf6026b0f830a04b41d0",
+    "wof:hierarchy":[],
+    "wof:id":1444828011,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Altliefering",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.00962131800918,
+    47.82447224601449,
+    13.00962131800918,
+    47.82447224601449
+],
+  "geometry": {"coordinates":[13.00962131800918,47.82447224601449],"type":"Point"}
+}

--- a/data/144/482/801/1/1444828011.geojson
+++ b/data/144/482/801/1/1444828011.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"5e94aba5dc44bf6026b0f830a04b41d0",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828011,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828011,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336666,
     "wof:name":"Altliefering",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/482/802/1/1444828021.geojson
+++ b/data/144/482/802/1/1444828021.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828021,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0045286946,47.8113316029,13.0045286946,47.8113316029",
+    "geom:latitude":47.811332,
+    "geom:longitude":13.004529,
+    "iso:country":"AT",
+    "lbl:latitude":47.811332,
+    "lbl:longitude":13.004529,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Taxham"
+    ],
+    "name:eng_x_preferred":[
+        "Taxham"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"f3a5f89eaaa8fd3decd9d29af571cd7c",
+    "wof:hierarchy":[],
+    "wof:id":1444828021,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Taxham",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.00452869459721,
+    47.81133160285885,
+    13.00452869459721,
+    47.81133160285885
+],
+  "geometry": {"coordinates":[13.00452869459721,47.81133160285885],"type":"Point"}
+}

--- a/data/144/482/802/1/1444828021.geojson
+++ b/data/144/482/802/1/1444828021.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"f3a5f89eaaa8fd3decd9d29af571cd7c",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828021,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828021,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336667,
     "wof:name":"Taxham",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/482/803/5/1444828035.geojson
+++ b/data/144/482/803/5/1444828035.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828035,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0199782263,47.8293895262,13.0199782263,47.8293895262",
+    "geom:latitude":47.82939,
+    "geom:longitude":13.019978,
+    "iso:country":"AT",
+    "lbl:latitude":47.829389,
+    "lbl:longitude":13.019978,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Salzachseesiuedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Salzachseesiuedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"76f4f269fd5325e71439e78d5b04d6b9",
+    "wof:hierarchy":[],
+    "wof:id":1444828035,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Salzachseesiuedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.019978226296454,
+    47.82938952616508,
+    13.019978226296454,
+    47.82938952616508
+],
+  "geometry": {"coordinates":[13.01997822629645,47.82938952616508],"type":"Point"}
+}

--- a/data/144/482/803/5/1444828035.geojson
+++ b/data/144/482/803/5/1444828035.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"76f4f269fd5325e71439e78d5b04d6b9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7545be4df59c20252631ad6b53533183",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828035,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828035,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336670,
     "wof:name":"Salzachseesiuedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.019978226296454,
+    13.01997822629645,
     47.82938952616508,
-    13.019978226296454,
+    13.01997822629645,
     47.82938952616508
 ],
   "geometry": {"coordinates":[13.01997822629645,47.82938952616508],"type":"Point"}

--- a/data/144/482/804/5/1444828045.geojson
+++ b/data/144/482/804/5/1444828045.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828045,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"12.9948584322,47.8305419463,12.9948584322,47.8305419463",
+    "geom:latitude":47.830542,
+    "geom:longitude":12.994858,
+    "iso:country":"AT",
+    "lbl:latitude":47.830542,
+    "lbl:longitude":12.994858,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Rott"
+    ],
+    "name:eng_x_preferred":[
+        "Rott"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"d2705b814d6915a7a8a9d317a708bcfb",
+    "wof:hierarchy":[],
+    "wof:id":1444828045,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Rott",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    12.994858432163243,
+    47.8305419463129,
+    12.994858432163243,
+    47.8305419463129
+],
+  "geometry": {"coordinates":[12.99485843216324,47.8305419463129],"type":"Point"}
+}

--- a/data/144/482/804/5/1444828045.geojson
+++ b/data/144/482/804/5/1444828045.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"d2705b814d6915a7a8a9d317a708bcfb",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c36a29de5f85b73878d3e61af366bf83",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828045,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828045,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336671,
     "wof:name":"Rott",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    12.994858432163243,
+    12.99485843216324,
     47.8305419463129,
-    12.994858432163243,
+    12.99485843216324,
     47.8305419463129
 ],
   "geometry": {"coordinates":[12.99485843216324,47.8305419463129],"type":"Point"}

--- a/data/144/482/805/3/1444828053.geojson
+++ b/data/144/482/805/3/1444828053.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828053,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0041281512,47.8286980618,13.0041281512,47.8286980618",
+    "geom:latitude":47.828698,
+    "geom:longitude":13.004128,
+    "iso:country":"AT",
+    "lbl:latitude":47.828698,
+    "lbl:longitude":13.004128,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Liefering-Nord"
+    ],
+    "name:eng_x_preferred":[
+        "Liefering-Nord"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"99df19e4e9b1334a6d1714c6364cbea8",
+    "wof:hierarchy":[],
+    "wof:id":1444828053,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Liefering-Nord",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.004128151182787,
+    47.82869806179316,
+    13.004128151182787,
+    47.82869806179316
+],
+  "geometry": {"coordinates":[13.00412815118279,47.82869806179316],"type":"Point"}
+}

--- a/data/144/482/805/3/1444828053.geojson
+++ b/data/144/482/805/3/1444828053.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"99df19e4e9b1334a6d1714c6364cbea8",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1563346a175896fcb640d5b22f3359ce",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828053,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828053,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336671,
     "wof:name":"Liefering-Nord",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.004128151182787,
+    13.00412815118279,
     47.82869806179316,
-    13.004128151182787,
+    13.00412815118279,
     47.82869806179316
 ],
   "geometry": {"coordinates":[13.00412815118279,47.82869806179316],"type":"Point"}

--- a/data/144/482/806/5/1444828065.geojson
+++ b/data/144/482/806/5/1444828065.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828065,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0040995409,47.838684986,13.0040995409,47.838684986",
+    "geom:latitude":47.838685,
+    "geom:longitude":13.0041,
+    "iso:country":"AT",
+    "lbl:latitude":47.838685,
+    "lbl:longitude":13.0041,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Herrenau"
+    ],
+    "name:eng_x_preferred":[
+        "Herrenau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"369c2d1b70af8b897913ce72498c51da",
+    "wof:hierarchy":[],
+    "wof:id":1444828065,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Herrenau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.0040995409389,
+    47.838684985992614,
+    13.0040995409389,
+    47.838684985992614
+],
+  "geometry": {"coordinates":[13.0040995409389,47.83868498599261],"type":"Point"}
+}

--- a/data/144/482/806/5/1444828065.geojson
+++ b/data/144/482/806/5/1444828065.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"369c2d1b70af8b897913ce72498c51da",
-    "wof:hierarchy":[],
+    "wof:geomhash":"30366cddaaa121dc082d71418619a22f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444828065,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828065,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336672,
     "wof:name":"Herrenau",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -46,9 +62,9 @@
 },
   "bbox": [
     13.0040995409389,
-    47.838684985992614,
+    47.83868498599261,
     13.0040995409389,
-    47.838684985992614
+    47.83868498599261
 ],
   "geometry": {"coordinates":[13.0040995409389,47.83868498599261],"type":"Point"}
 }

--- a/data/144/482/807/5/1444828075.geojson
+++ b/data/144/482/807/5/1444828075.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"e25cc63fb1b9e552ad7036716b92dcd4",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1c55746431ebb202253c06d8911947aa",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828075,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828075,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336675,
     "wof:name":"Forellenwegsiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.002368621183706,
+    13.00236862118371,
     47.83435435393049,
-    13.002368621183706,
+    13.00236862118371,
     47.83435435393049
 ],
   "geometry": {"coordinates":[13.00236862118371,47.83435435393049],"type":"Point"}

--- a/data/144/482/807/5/1444828075.geojson
+++ b/data/144/482/807/5/1444828075.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828075,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0023686212,47.8343543539,13.0023686212,47.8343543539",
+    "geom:latitude":47.834354,
+    "geom:longitude":13.002369,
+    "iso:country":"AT",
+    "lbl:latitude":47.834354,
+    "lbl:longitude":13.002369,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Forellenwegsiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Forellenwegsiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"e25cc63fb1b9e552ad7036716b92dcd4",
+    "wof:hierarchy":[],
+    "wof:id":1444828075,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Forellenwegsiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.002368621183706,
+    47.83435435393049,
+    13.002368621183706,
+    47.83435435393049
+],
+  "geometry": {"coordinates":[13.00236862118371,47.83435435393049],"type":"Point"}
+}

--- a/data/144/482/809/1/1444828091.geojson
+++ b/data/144/482/809/1/1444828091.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837115,
+        85632785,
+        101754151,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"ba1237253cd34d236c5d9fdf4280d73c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7b221446870f2a9d2dedc9a068159c30",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837115,
+            "locality_id":101754151,
+            "neighbourhood_id":1444828091,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828091,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336676,
     "wof:name":"Schlachthofsiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":101754151,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -46,9 +63,9 @@
 },
   "bbox": [
     13.01681679434688,
-    47.844570609256174,
+    47.84457060925617,
     13.01681679434688,
-    47.844570609256174
+    47.84457060925617
 ],
   "geometry": {"coordinates":[13.01681679434688,47.84457060925617],"type":"Point"}
 }

--- a/data/144/482/809/1/1444828091.geojson
+++ b/data/144/482/809/1/1444828091.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828091,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0168167943,47.8445706093,13.0168167943,47.8445706093",
+    "geom:latitude":47.844571,
+    "geom:longitude":13.016817,
+    "iso:country":"AT",
+    "lbl:latitude":47.844571,
+    "lbl:longitude":13.016817,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Schlachthofsiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Schlachthofsiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"ba1237253cd34d236c5d9fdf4280d73c",
+    "wof:hierarchy":[],
+    "wof:id":1444828091,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Schlachthofsiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.01681679434688,
+    47.844570609256174,
+    13.01681679434688,
+    47.844570609256174
+],
+  "geometry": {"coordinates":[13.01681679434688,47.84457060925617],"type":"Point"}
+}

--- a/data/144/482/810/5/1444828105.geojson
+++ b/data/144/482/810/5/1444828105.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"2fa0feb54875460ad0fca4338c940086",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b4bed286f1e320ae09b42ba1cc5ac7cd",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828105,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828105,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336677,
     "wof:name":"Schallmoos West",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.050805764085206,
+    13.05080576408521,
     47.81049579157993,
-    13.050805764085206,
+    13.05080576408521,
     47.81049579157993
 ],
   "geometry": {"coordinates":[13.05080576408521,47.81049579157993],"type":"Point"}

--- a/data/144/482/810/5/1444828105.geojson
+++ b/data/144/482/810/5/1444828105.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828105,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0508057641,47.8104957916,13.0508057641,47.8104957916",
+    "geom:latitude":47.810496,
+    "geom:longitude":13.050806,
+    "iso:country":"AT",
+    "lbl:latitude":47.810496,
+    "lbl:longitude":13.050806,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Schallmoos West"
+    ],
+    "name:eng_x_preferred":[
+        "Schallmoos West"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"2fa0feb54875460ad0fca4338c940086",
+    "wof:hierarchy":[],
+    "wof:id":1444828105,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Schallmoos West",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.050805764085206,
+    47.81049579157993,
+    13.050805764085206,
+    47.81049579157993
+],
+  "geometry": {"coordinates":[13.05080576408521,47.81049579157993],"type":"Point"}
+}

--- a/data/144/482/811/5/1444828115.geojson
+++ b/data/144/482/811/5/1444828115.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"7eeb15e4df793063d1505e7cda3a11b9",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828115,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828115,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336677,
     "wof:name":"Schallmoos Ost",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/482/811/5/1444828115.geojson
+++ b/data/144/482/811/5/1444828115.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828115,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0581299865,47.8176045616,13.0581299865,47.8176045616",
+    "geom:latitude":47.817605,
+    "geom:longitude":13.05813,
+    "iso:country":"AT",
+    "lbl:latitude":47.817605,
+    "lbl:longitude":13.05813,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Schallmoos Ost"
+    ],
+    "name:eng_x_preferred":[
+        "Schallmoos Ost"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"7eeb15e4df793063d1505e7cda3a11b9",
+    "wof:hierarchy":[],
+    "wof:id":1444828115,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Schallmoos Ost",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.0581299865204,
+    47.81760456157767,
+    13.0581299865204,
+    47.81760456157767
+],
+  "geometry": {"coordinates":[13.0581299865204,47.81760456157767],"type":"Point"}
+}

--- a/data/144/482/812/5/1444828125.geojson
+++ b/data/144/482/812/5/1444828125.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828125,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0449692743,47.8209088476,13.0449692743,47.8209088476",
+    "geom:latitude":47.820909,
+    "geom:longitude":13.044969,
+    "iso:country":"AT",
+    "lbl:latitude":47.820909,
+    "lbl:longitude":13.044969,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Itzling Mitte"
+    ],
+    "name:eng_x_preferred":[
+        "Itzling Mitte"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"d2664b0a58cf9231f8d04e848a42e2d5",
+    "wof:hierarchy":[],
+    "wof:id":1444828125,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Itzling Mitte",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.044969274332159,
+    47.82090884763261,
+    13.044969274332159,
+    47.82090884763261
+],
+  "geometry": {"coordinates":[13.04496927433216,47.82090884763261],"type":"Point"}
+}

--- a/data/144/482/812/5/1444828125.geojson
+++ b/data/144/482/812/5/1444828125.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"d2664b0a58cf9231f8d04e848a42e2d5",
-    "wof:hierarchy":[],
+    "wof:geomhash":"413d2aee36ccc2846ffae2a5cd8a1bab",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828125,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828125,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336680,
     "wof:name":"Itzling Mitte",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.044969274332159,
+    13.04496927433216,
     47.82090884763261,
-    13.044969274332159,
+    13.04496927433216,
     47.82090884763261
 ],
   "geometry": {"coordinates":[13.04496927433216,47.82090884763261],"type":"Point"}

--- a/data/144/482/814/1/1444828141.geojson
+++ b/data/144/482/814/1/1444828141.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828141,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0368725753,47.8217733064,13.0368725753,47.8217733064",
+    "geom:latitude":47.821773,
+    "geom:longitude":13.036873,
+    "iso:country":"AT",
+    "lbl:latitude":47.821773,
+    "lbl:longitude":13.036872,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Austra\u00dfensiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Austrassensiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"e5b9d110e9f545c693ad36f5285c5b11",
+    "wof:hierarchy":[],
+    "wof:id":1444828141,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Austrassensiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.036872575312,
+    47.82177330636958,
+    13.036872575312,
+    47.82177330636958
+],
+  "geometry": {"coordinates":[13.036872575312,47.82177330636958],"type":"Point"}
+}

--- a/data/144/482/814/1/1444828141.geojson
+++ b/data/144/482/814/1/1444828141.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"e5b9d110e9f545c693ad36f5285c5b11",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828141,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828141,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336681,
     "wof:name":"Austrassensiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/482/815/3/1444828153.geojson
+++ b/data/144/482/815/3/1444828153.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"54495529fa4a2a59551c454f6967d74b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"5438522d3db321afca871295614aef48",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828153,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828153,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336682,
     "wof:name":"Kirchenviertel Itzling",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.044654561649395,
+    13.04465456164939,
     47.82392478561674,
-    13.044654561649395,
+    13.04465456164939,
     47.82392478561674
 ],
   "geometry": {"coordinates":[13.04465456164939,47.82392478561674],"type":"Point"}

--- a/data/144/482/815/3/1444828153.geojson
+++ b/data/144/482/815/3/1444828153.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828153,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0446545616,47.8239247856,13.0446545616,47.8239247856",
+    "geom:latitude":47.823925,
+    "geom:longitude":13.044655,
+    "iso:country":"AT",
+    "lbl:latitude":47.823925,
+    "lbl:longitude":13.044655,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Kirchenviertel Itzling"
+    ],
+    "name:eng_x_preferred":[
+        "Kirchenviertel Itzling"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"54495529fa4a2a59551c454f6967d74b",
+    "wof:hierarchy":[],
+    "wof:id":1444828153,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Kirchenviertel Itzling",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.044654561649395,
+    47.82392478561674,
+    13.044654561649395,
+    47.82392478561674
+],
+  "geometry": {"coordinates":[13.04465456164939,47.82392478561674],"type":"Point"}
+}

--- a/data/144/482/816/1/1444828161.geojson
+++ b/data/144/482/816/1/1444828161.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828161,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0415074348,47.8259801334,13.0415074348,47.8259801334",
+    "geom:latitude":47.82598,
+    "geom:longitude":13.041507,
+    "iso:country":"AT",
+    "lbl:latitude":47.82598,
+    "lbl:longitude":13.041507,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Goethesiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Goethesiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"b12d42f87c759474d538681ba9f6a96b",
+    "wof:hierarchy":[],
+    "wof:id":1444828161,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Goethesiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.041507434821773,
+    47.825980133396655,
+    13.041507434821773,
+    47.825980133396655
+],
+  "geometry": {"coordinates":[13.04150743482177,47.82598013339665],"type":"Point"}
+}

--- a/data/144/482/816/1/1444828161.geojson
+++ b/data/144/482/816/1/1444828161.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"b12d42f87c759474d538681ba9f6a96b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"df7100d7ba8ee1f8ccb859d3c0f142f4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828161,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828161,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336685,
     "wof:name":"Goethesiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.041507434821773,
-    47.825980133396655,
-    13.041507434821773,
-    47.825980133396655
+    13.04150743482177,
+    47.82598013339665,
+    13.04150743482177,
+    47.82598013339665
 ],
   "geometry": {"coordinates":[13.04150743482177,47.82598013339665],"type":"Point"}
 }

--- a/data/144/482/817/1/1444828171.geojson
+++ b/data/144/482/817/1/1444828171.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"7e32ac0dfb8c97122baf298f0ee093d0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c37077014846d3889db555ae4fac79a0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828171,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828171,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336686,
     "wof:name":"Grabenbauernsiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.038932512871899,
+    13.0389325128719,
     47.827920153363,
-    13.038932512871899,
+    13.0389325128719,
     47.827920153363
 ],
   "geometry": {"coordinates":[13.0389325128719,47.827920153363],"type":"Point"}

--- a/data/144/482/817/1/1444828171.geojson
+++ b/data/144/482/817/1/1444828171.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828171,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0389325129,47.8279201534,13.0389325129,47.8279201534",
+    "geom:latitude":47.82792,
+    "geom:longitude":13.038933,
+    "iso:country":"AT",
+    "lbl:latitude":47.82792,
+    "lbl:longitude":13.038932,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Grabenbauernsiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Grabenbauernsiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"7e32ac0dfb8c97122baf298f0ee093d0",
+    "wof:hierarchy":[],
+    "wof:id":1444828171,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Grabenbauernsiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.038932512871899,
+    47.827920153363,
+    13.038932512871899,
+    47.827920153363
+],
+  "geometry": {"coordinates":[13.0389325128719,47.827920153363],"type":"Point"}
+}

--- a/data/144/482/818/1/1444828181.geojson
+++ b/data/144/482/818/1/1444828181.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"edd184217ee751fcd3428bc15ad87082",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d8dd9ea6d7150f73b0ab5607e924c3de",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828181,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828181,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336686,
     "wof:name":"Wasserfeldsiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.034655281410723,
+    13.03465528141072,
     47.82585527814302,
-    13.034655281410723,
+    13.03465528141072,
     47.82585527814302
 ],
   "geometry": {"coordinates":[13.03465528141072,47.82585527814302],"type":"Point"}

--- a/data/144/482/818/1/1444828181.geojson
+++ b/data/144/482/818/1/1444828181.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828181,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0346552814,47.8258552781,13.0346552814,47.8258552781",
+    "geom:latitude":47.825855,
+    "geom:longitude":13.034655,
+    "iso:country":"AT",
+    "lbl:latitude":47.825855,
+    "lbl:longitude":13.034655,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Wasserfeldsiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Wasserfeldsiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"edd184217ee751fcd3428bc15ad87082",
+    "wof:hierarchy":[],
+    "wof:id":1444828181,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Wasserfeldsiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.034655281410723,
+    47.82585527814302,
+    13.034655281410723,
+    47.82585527814302
+],
+  "geometry": {"coordinates":[13.03465528141072,47.82585527814302],"type":"Point"}
+}

--- a/data/144/482/819/9/1444828199.geojson
+++ b/data/144/482/819/9/1444828199.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"b851aff08eaa137da34d2b14c876a036",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e88cc8a44a9dbc2da3306f4fba625a53",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828199,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828199,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336689,
     "wof:name":"Itzling-Ost",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.056542117984645,
+    13.05654211798464,
     47.82566319255102,
-    13.056542117984645,
+    13.05654211798464,
     47.82566319255102
 ],
   "geometry": {"coordinates":[13.05654211798464,47.82566319255102],"type":"Point"}

--- a/data/144/482/819/9/1444828199.geojson
+++ b/data/144/482/819/9/1444828199.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828199,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.056542118,47.8256631926,13.056542118,47.8256631926",
+    "geom:latitude":47.825663,
+    "geom:longitude":13.056542,
+    "iso:country":"AT",
+    "lbl:latitude":47.825663,
+    "lbl:longitude":13.056542,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Itzling-Ost"
+    ],
+    "name:eng_x_preferred":[
+        "Itzling-Ost"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"b851aff08eaa137da34d2b14c876a036",
+    "wof:hierarchy":[],
+    "wof:id":1444828199,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Itzling-Ost",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.056542117984645,
+    47.82566319255102,
+    13.056542117984645,
+    47.82566319255102
+],
+  "geometry": {"coordinates":[13.05654211798464,47.82566319255102],"type":"Point"}
+}

--- a/data/144/482/821/1/1444828211.geojson
+++ b/data/144/482/821/1/1444828211.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"ce6854d65925441683ac67b983d80452",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6713a21080969d6ce4bbc3d2a9c7bae2",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828211,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828211,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336690,
     "wof:name":"Haganau",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.029133504340434,
-    47.831963229252175,
-    13.029133504340434,
-    47.831963229252175
+    13.02913350434043,
+    47.83196322925217,
+    13.02913350434043,
+    47.83196322925217
 ],
   "geometry": {"coordinates":[13.02913350434043,47.83196322925217],"type":"Point"}
 }

--- a/data/144/482/821/1/1444828211.geojson
+++ b/data/144/482/821/1/1444828211.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828211,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0291335043,47.8319632293,13.0291335043,47.8319632293",
+    "geom:latitude":47.831963,
+    "geom:longitude":13.029134,
+    "iso:country":"AT",
+    "lbl:latitude":47.831963,
+    "lbl:longitude":13.029134,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Haganau"
+    ],
+    "name:eng_x_preferred":[
+        "Haganau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"ce6854d65925441683ac67b983d80452",
+    "wof:hierarchy":[],
+    "wof:id":1444828211,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Haganau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.029133504340434,
+    47.831963229252175,
+    13.029133504340434,
+    47.831963229252175
+],
+  "geometry": {"coordinates":[13.02913350434043,47.83196322925217],"type":"Point"}
+}

--- a/data/144/482/821/9/1444828219.geojson
+++ b/data/144/482/821/9/1444828219.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"3852dcd8cd0df984aec403828db25e60",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828219,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828219,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336691,
     "wof:name":"Gnigl Nord",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/482/821/9/1444828219.geojson
+++ b/data/144/482/821/9/1444828219.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828219,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0655829551,47.8215523905,13.0655829551,47.8215523905",
+    "geom:latitude":47.821552,
+    "geom:longitude":13.065583,
+    "iso:country":"AT",
+    "lbl:latitude":47.821552,
+    "lbl:longitude":13.065583,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Gnigl Nord"
+    ],
+    "name:eng_x_preferred":[
+        "Gnigl Nord"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"3852dcd8cd0df984aec403828db25e60",
+    "wof:hierarchy":[],
+    "wof:id":1444828219,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Gnigl Nord",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.06558295505309,
+    47.82155239050609,
+    13.06558295505309,
+    47.82155239050609
+],
+  "geometry": {"coordinates":[13.06558295505309,47.82155239050609],"type":"Point"}
+}

--- a/data/144/482/823/1/1444828231.geojson
+++ b/data/144/482/823/1/1444828231.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"6675b49f47895ae020ac76fb65e09cf1",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8f5ed0616e4afa2ba3c1e3423951e1d5",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828231,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828231,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336694,
     "wof:name":"Inneres Parsch",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.064266883834271,
+    13.06426688383427,
     47.80157002551812,
-    13.064266883834271,
+    13.06426688383427,
     47.80157002551812
 ],
   "geometry": {"coordinates":[13.06426688383427,47.80157002551812],"type":"Point"}

--- a/data/144/482/823/1/1444828231.geojson
+++ b/data/144/482/823/1/1444828231.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828231,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0642668838,47.8015700255,13.0642668838,47.8015700255",
+    "geom:latitude":47.80157,
+    "geom:longitude":13.064267,
+    "iso:country":"AT",
+    "lbl:latitude":47.80157,
+    "lbl:longitude":13.064267,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Inneres Parsch"
+    ],
+    "name:eng_x_preferred":[
+        "Inneres Parsch"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"6675b49f47895ae020ac76fb65e09cf1",
+    "wof:hierarchy":[],
+    "wof:id":1444828231,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Inneres Parsch",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.064266883834271,
+    47.80157002551812,
+    13.064266883834271,
+    47.80157002551812
+],
+  "geometry": {"coordinates":[13.06426688383427,47.80157002551812],"type":"Point"}
+}

--- a/data/144/482/824/3/1444828243.geojson
+++ b/data/144/482/824/3/1444828243.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"1c393b1f8d433b051094da30add0648b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"024246215fd27035b45c1097db394357",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828243,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828243,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336695,
     "wof:name":"Parsch Sued",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -43,9 +60,9 @@
 },
   "bbox": [
     13.07236358285443,
-    47.800609140238386,
+    47.80060914023839,
     13.07236358285443,
-    47.800609140238386
+    47.80060914023839
 ],
   "geometry": {"coordinates":[13.07236358285443,47.80060914023839],"type":"Point"}
 }

--- a/data/144/482/824/3/1444828243.geojson
+++ b/data/144/482/824/3/1444828243.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444828243,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0723635829,47.8006091402,13.0723635829,47.8006091402",
+    "geom:latitude":47.800609,
+    "geom:longitude":13.072364,
+    "iso:country":"AT",
+    "lbl:latitude":47.800609,
+    "lbl:longitude":13.072363,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Parsch Sued"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"1c393b1f8d433b051094da30add0648b",
+    "wof:hierarchy":[],
+    "wof:id":1444828243,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Parsch Sued",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.07236358285443,
+    47.800609140238386,
+    13.07236358285443,
+    47.800609140238386
+],
+  "geometry": {"coordinates":[13.07236358285443,47.80060914023839],"type":"Point"}
+}

--- a/data/144/482/824/9/1444828249.geojson
+++ b/data/144/482/824/9/1444828249.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"27823bbcbff8615cfacb1f39c620e4f0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"4f80b092fbfd9505b6940dd932536719",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828249,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828249,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336695,
     "wof:name":"Parsch-Gersberg",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.082634660410035,
+    13.08263466041003,
     47.80076288386572,
-    13.082634660410035,
+    13.08263466041003,
     47.80076288386572
 ],
   "geometry": {"coordinates":[13.08263466041003,47.80076288386572],"type":"Point"}

--- a/data/144/482/824/9/1444828249.geojson
+++ b/data/144/482/824/9/1444828249.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828249,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0826346604,47.8007628839,13.0826346604,47.8007628839",
+    "geom:latitude":47.800763,
+    "geom:longitude":13.082635,
+    "iso:country":"AT",
+    "lbl:latitude":47.800763,
+    "lbl:longitude":13.082635,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Parsch-Gersberg"
+    ],
+    "name:eng_x_preferred":[
+        "Parsch-Gersberg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"27823bbcbff8615cfacb1f39c620e4f0",
+    "wof:hierarchy":[],
+    "wof:id":1444828249,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Parsch-Gersberg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.082634660410035,
+    47.80076288386572,
+    13.082634660410035,
+    47.80076288386572
+],
+  "geometry": {"coordinates":[13.08263466041003,47.80076288386572],"type":"Point"}
+}

--- a/data/144/482/826/1/1444828261.geojson
+++ b/data/144/482/826/1/1444828261.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828261,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0732505004,47.8054902495,13.0732505004,47.8054902495",
+    "geom:latitude":47.80549,
+    "geom:longitude":13.073251,
+    "iso:country":"AT",
+    "lbl:latitude":47.80549,
+    "lbl:longitude":13.073251,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Wolfsgartenfeld"
+    ],
+    "name:eng_x_preferred":[
+        "Wolfsgartenfeld"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"475a66c12c731b087721693ddc05f496",
+    "wof:hierarchy":[],
+    "wof:id":1444828261,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Wolfsgartenfeld",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.073250500414941,
+    47.80549024945058,
+    13.073250500414941,
+    47.80549024945058
+],
+  "geometry": {"coordinates":[13.07325050041494,47.80549024945058],"type":"Point"}
+}

--- a/data/144/482/826/1/1444828261.geojson
+++ b/data/144/482/826/1/1444828261.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"475a66c12c731b087721693ddc05f496",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d6de86c604e813f8963d346162deccc2",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828261,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828261,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336698,
     "wof:name":"Wolfsgartenfeld",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.073250500414941,
+    13.07325050041494,
     47.80549024945058,
-    13.073250500414941,
+    13.07325050041494,
     47.80549024945058
 ],
   "geometry": {"coordinates":[13.07325050041494,47.80549024945058],"type":"Point"}

--- a/data/144/482/827/3/1444828273.geojson
+++ b/data/144/482/827/3/1444828273.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"c735debb3e044c0ab24dbb208cace6e2",
-    "wof:hierarchy":[],
+    "wof:geomhash":"42da1a124aabc978fe193ae224ddeb41",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828273,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828273,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336699,
     "wof:name":"Weichselbaumsiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.070160594075091,
+    13.07016059407509,
     47.79886028606736,
-    13.070160594075091,
+    13.07016059407509,
     47.79886028606736
 ],
   "geometry": {"coordinates":[13.07016059407509,47.79886028606736],"type":"Point"}

--- a/data/144/482/827/3/1444828273.geojson
+++ b/data/144/482/827/3/1444828273.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828273,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0701605941,47.7988602861,13.0701605941,47.7988602861",
+    "geom:latitude":47.79886,
+    "geom:longitude":13.070161,
+    "iso:country":"AT",
+    "lbl:latitude":47.79886,
+    "lbl:longitude":13.070161,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Weichselbaumsiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Weichselbaumsiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"c735debb3e044c0ab24dbb208cace6e2",
+    "wof:hierarchy":[],
+    "wof:id":1444828273,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Weichselbaumsiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.070160594075091,
+    47.79886028606736,
+    13.070160594075091,
+    47.79886028606736
+],
+  "geometry": {"coordinates":[13.07016059407509,47.79886028606736],"type":"Point"}
+}

--- a/data/144/482/828/3/1444828283.geojson
+++ b/data/144/482/828/3/1444828283.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"894e31dae52216ca217631f185100cb4",
-    "wof:hierarchy":[],
+    "wof:geomhash":"fee105cca870af1ca462915b63fe0a3d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828283,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828283,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336700,
     "wof:name":"Rennbahnsiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.066469872613604,
+    13.0664698726136,
     47.79363258796378,
-    13.066469872613604,
+    13.0664698726136,
     47.79363258796378
 ],
   "geometry": {"coordinates":[13.0664698726136,47.79363258796378],"type":"Point"}

--- a/data/144/482/828/3/1444828283.geojson
+++ b/data/144/482/828/3/1444828283.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828283,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0664698726,47.793632588,13.0664698726,47.793632588",
+    "geom:latitude":47.793633,
+    "geom:longitude":13.06647,
+    "iso:country":"AT",
+    "lbl:latitude":47.793633,
+    "lbl:longitude":13.06647,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Rennbahnsiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Rennbahnsiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"894e31dae52216ca217631f185100cb4",
+    "wof:hierarchy":[],
+    "wof:id":1444828283,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Rennbahnsiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.066469872613604,
+    47.79363258796378,
+    13.066469872613604,
+    47.79363258796378
+],
+  "geometry": {"coordinates":[13.0664698726136,47.79363258796378],"type":"Point"}
+}

--- a/data/144/482/829/5/1444828295.geojson
+++ b/data/144/482/829/5/1444828295.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"a9fc11b13c211c2cce95a26ca0c8a034",
-    "wof:hierarchy":[],
+    "wof:geomhash":"fa9db654cd26f0294416a6726e0aae73",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828295,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828295,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336700,
     "wof:name":"Abfalter",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.077456206266394,
+    13.07745620626639,
     47.79611196623868,
-    13.077456206266394,
+    13.07745620626639,
     47.79611196623868
 ],
   "geometry": {"coordinates":[13.07745620626639,47.79611196623868],"type":"Point"}

--- a/data/144/482/829/5/1444828295.geojson
+++ b/data/144/482/829/5/1444828295.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828295,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0774562063,47.7961119662,13.0774562063,47.7961119662",
+    "geom:latitude":47.796112,
+    "geom:longitude":13.077456,
+    "iso:country":"AT",
+    "lbl:latitude":47.796112,
+    "lbl:longitude":13.077456,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Abfalter"
+    ],
+    "name:eng_x_preferred":[
+        "Abfalter"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"a9fc11b13c211c2cce95a26ca0c8a034",
+    "wof:hierarchy":[],
+    "wof:id":1444828295,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Abfalter",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.077456206266394,
+    47.79611196623868,
+    13.077456206266394,
+    47.79611196623868
+],
+  "geometry": {"coordinates":[13.07745620626639,47.79611196623868],"type":"Point"}
+}

--- a/data/144/482/830/5/1444828305.geojson
+++ b/data/144/482/830/5/1444828305.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"6772f352b358adcf00889ecec21def30",
-    "wof:hierarchy":[],
+    "wof:geomhash":"10b196eb3a59758b394d42ec2e0b18c6",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828305,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828305,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336704,
     "wof:name":"Aigen Mitte",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -46,9 +63,9 @@
 },
   "bbox": [
     13.07645484773033,
-    47.789884465990774,
+    47.78988446599077,
     13.07645484773033,
-    47.789884465990774
+    47.78988446599077
 ],
   "geometry": {"coordinates":[13.07645484773033,47.78988446599077],"type":"Point"}
 }

--- a/data/144/482/830/5/1444828305.geojson
+++ b/data/144/482/830/5/1444828305.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828305,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0764548477,47.789884466,13.0764548477,47.789884466",
+    "geom:latitude":47.789884,
+    "geom:longitude":13.076455,
+    "iso:country":"AT",
+    "lbl:latitude":47.789884,
+    "lbl:longitude":13.076455,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Aigen Mitte"
+    ],
+    "name:eng_x_preferred":[
+        "Aigen Mitte"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"6772f352b358adcf00889ecec21def30",
+    "wof:hierarchy":[],
+    "wof:id":1444828305,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Aigen Mitte",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.07645484773033,
+    47.789884465990774,
+    13.07645484773033,
+    47.789884465990774
+],
+  "geometry": {"coordinates":[13.07645484773033,47.78988446599077],"type":"Point"}
+}

--- a/data/144/482/832/3/1444828323.geojson
+++ b/data/144/482/832/3/1444828323.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828323,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0813185892,47.780041953,13.0813185892,47.780041953",
+    "geom:latitude":47.780042,
+    "geom:longitude":13.081319,
+    "iso:country":"AT",
+    "lbl:latitude":47.780042,
+    "lbl:longitude":13.081319,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Glas"
+    ],
+    "name:eng_x_preferred":[
+        "Glas"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"6a8417e7001280b28b6ec608a1b52c61",
+    "wof:hierarchy":[],
+    "wof:id":1444828323,
+    "wof:lastmodified":1566333178,
+    "wof:name":"Glas",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.081318589191206,
+    47.780041952990004,
+    13.081318589191206,
+    47.780041952990004
+],
+  "geometry": {"coordinates":[13.08131858919121,47.78004195299],"type":"Point"}
+}

--- a/data/144/482/832/3/1444828323.geojson
+++ b/data/144/482/832/3/1444828323.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"6a8417e7001280b28b6ec608a1b52c61",
-    "wof:hierarchy":[],
+    "wof:geomhash":"31e8de705ad57cb5157ab9593ef8f550",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828323,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828323,
-    "wof:lastmodified":1566333178,
+    "wof:lastmodified":1566336704,
     "wof:name":"Glas",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.081318589191206,
-    47.780041952990004,
-    13.081318589191206,
-    47.780041952990004
+    13.08131858919121,
+    47.78004195299,
+    13.08131858919121,
+    47.78004195299
 ],
   "geometry": {"coordinates":[13.08131858919121,47.78004195299],"type":"Point"}
 }

--- a/data/144/482/833/1/1444828331.geojson
+++ b/data/144/482/833/1/1444828331.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"aefab2ed0ad7edbd75d902ec5ac6c151",
-    "wof:hierarchy":[],
+    "wof:geomhash":"955dae701b2519925ce1208eca6574f5",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444828331,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828331,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566336705,
     "wof:name":"Oberjudenberg",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.103005154057918,
+    13.10300515405792,
     47.79816841504744,
-    13.103005154057918,
+    13.10300515405792,
     47.79816841504744
 ],
   "geometry": {"coordinates":[13.10300515405792,47.79816841504744],"type":"Point"}

--- a/data/144/482/833/1/1444828331.geojson
+++ b/data/144/482/833/1/1444828331.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828331,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.1030051541,47.798168415,13.1030051541,47.798168415",
+    "geom:latitude":47.798168,
+    "geom:longitude":13.103005,
+    "iso:country":"AT",
+    "lbl:latitude":47.798168,
+    "lbl:longitude":13.103005,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Oberjudenberg"
+    ],
+    "name:eng_x_preferred":[
+        "Oberjudenberg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"aefab2ed0ad7edbd75d902ec5ac6c151",
+    "wof:hierarchy":[],
+    "wof:id":1444828331,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Oberjudenberg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.103005154057918,
+    47.79816841504744,
+    13.103005154057918,
+    47.79816841504744
+],
+  "geometry": {"coordinates":[13.10300515405792,47.79816841504744],"type":"Point"}
+}

--- a/data/144/482/834/3/1444828343.geojson
+++ b/data/144/482/834/3/1444828343.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"3c718a1d31c83c868cbba4122cd2f139",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b60e3d318a1fbd6df713d2fc60786e42",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444828343,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828343,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566336708,
     "wof:name":"Zistelalm",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.114620913076237,
+    13.11462091307624,
     47.79538161903866,
-    13.114620913076237,
+    13.11462091307624,
     47.79538161903866
 ],
   "geometry": {"coordinates":[13.11462091307624,47.79538161903866],"type":"Point"}

--- a/data/144/482/834/3/1444828343.geojson
+++ b/data/144/482/834/3/1444828343.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828343,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.1146209131,47.795381619,13.1146209131,47.795381619",
+    "geom:latitude":47.795382,
+    "geom:longitude":13.114621,
+    "iso:country":"AT",
+    "lbl:latitude":47.795382,
+    "lbl:longitude":13.114621,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Zistelalm"
+    ],
+    "name:eng_x_preferred":[
+        "Zistelalm"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"3c718a1d31c83c868cbba4122cd2f139",
+    "wof:hierarchy":[],
+    "wof:id":1444828343,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Zistelalm",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.114620913076237,
+    47.79538161903866,
+    13.114620913076237,
+    47.79538161903866
+],
+  "geometry": {"coordinates":[13.11462091307624,47.79538161903866],"type":"Point"}
+}

--- a/data/144/482/835/5/1444828355.geojson
+++ b/data/144/482/835/5/1444828355.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"7c39c7ae959f157ca54050a70461b267",
-    "wof:hierarchy":[],
+    "wof:geomhash":"89d5582939bbc1fe3bdd9e2a41f161b0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444828355,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828355,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566336709,
     "wof:name":"Hiesl",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,10 +61,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.091131902844605,
-    47.808526298018265,
-    13.091131902844605,
-    47.808526298018265
+    13.09113190284461,
+    47.80852629801826,
+    13.09113190284461,
+    47.80852629801826
 ],
   "geometry": {"coordinates":[13.09113190284461,47.80852629801826],"type":"Point"}
 }

--- a/data/144/482/835/5/1444828355.geojson
+++ b/data/144/482/835/5/1444828355.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828355,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0911319028,47.808526298,13.0911319028,47.808526298",
+    "geom:latitude":47.808526,
+    "geom:longitude":13.091132,
+    "iso:country":"AT",
+    "lbl:latitude":47.808526,
+    "lbl:longitude":13.091132,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Hiesl"
+    ],
+    "name:eng_x_preferred":[
+        "Hiesl"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"7c39c7ae959f157ca54050a70461b267",
+    "wof:hierarchy":[],
+    "wof:id":1444828355,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Hiesl",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.091131902844605,
+    47.808526298018265,
+    13.091131902844605,
+    47.808526298018265
+],
+  "geometry": {"coordinates":[13.09113190284461,47.80852629801826],"type":"Point"}
+}

--- a/data/144/482/841/5/1444828415.geojson
+++ b/data/144/482/841/5/1444828415.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"2a644e60c24c368d4f7ff31ea69f40c1",
-    "wof:hierarchy":[],
+    "wof:geomhash":"51afeb22d9f926ae82f91918f220e8b5",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444828415,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828415,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566336709,
     "wof:name":"Hostetter",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.100716334546917,
+    13.10071633454692,
     47.78488654951004,
-    13.100716334546917,
+    13.10071633454692,
     47.78488654951004
 ],
   "geometry": {"coordinates":[13.10071633454692,47.78488654951004],"type":"Point"}

--- a/data/144/482/841/5/1444828415.geojson
+++ b/data/144/482/841/5/1444828415.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828415,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.1007163345,47.7848865495,13.1007163345,47.7848865495",
+    "geom:latitude":47.784887,
+    "geom:longitude":13.100716,
+    "iso:country":"AT",
+    "lbl:latitude":47.784886,
+    "lbl:longitude":13.100716,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Hostetter"
+    ],
+    "name:eng_x_preferred":[
+        "Hostetter"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"2a644e60c24c368d4f7ff31ea69f40c1",
+    "wof:hierarchy":[],
+    "wof:id":1444828415,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Hostetter",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.100716334546917,
+    47.78488654951004,
+    13.100716334546917,
+    47.78488654951004
+],
+  "geometry": {"coordinates":[13.10071633454692,47.78488654951004],"type":"Point"}
+}

--- a/data/144/482/842/1/1444828421.geojson
+++ b/data/144/482/842/1/1444828421.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828421,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0598609063,47.7761582661,13.0598609063,47.7761582661",
+    "geom:latitude":47.776158,
+    "geom:longitude":13.059861,
+    "iso:country":"AT",
+    "lbl:latitude":47.776158,
+    "lbl:longitude":13.059861,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Hellbrunner Allee"
+    ],
+    "name:eng_x_preferred":[
+        "Hellbrunner Allee"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"461f46cf6dee04eff79fbafc91faf6d1",
+    "wof:hierarchy":[],
+    "wof:id":1444828421,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Hellbrunner Allee",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.059860906275585,
+    47.77615826613631,
+    13.059860906275585,
+    47.77615826613631
+],
+  "geometry": {"coordinates":[13.05986090627558,47.77615826613631],"type":"Point"}
+}

--- a/data/144/482/842/1/1444828421.geojson
+++ b/data/144/482/842/1/1444828421.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"461f46cf6dee04eff79fbafc91faf6d1",
-    "wof:hierarchy":[],
+    "wof:geomhash":"909159fbc08bf11a09620f1f4d5d431c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444828421,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828421,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566336710,
     "wof:name":"Hellbrunner Allee",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.059860906275585,
+    13.05986090627558,
     47.77615826613631,
-    13.059860906275585,
+    13.05986090627558,
     47.77615826613631
 ],
   "geometry": {"coordinates":[13.05986090627558,47.77615826613631],"type":"Point"}

--- a/data/144/482/842/5/1444828425.geojson
+++ b/data/144/482/842/5/1444828425.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837079,
+        85632785,
+        101754149,
+        102049779
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"8fdac26e6bce694a686c581df69be11e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"451a37691a3f0e78ae0be0ecc411e45c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":101754149,
+            "neighbourhood_id":1444828425,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828425,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566336713,
     "wof:name":"Kendlersiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":101754149,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.005158119962717,
+    13.00515811996272,
     47.77904222230038,
-    13.005158119962717,
+    13.00515811996272,
     47.77904222230038
 ],
   "geometry": {"coordinates":[13.00515811996272,47.77904222230038],"type":"Point"}

--- a/data/144/482/842/5/1444828425.geojson
+++ b/data/144/482/842/5/1444828425.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828425,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.00515812,47.7790422223,13.00515812,47.7790422223",
+    "geom:latitude":47.779042,
+    "geom:longitude":13.005158,
+    "iso:country":"AT",
+    "lbl:latitude":47.779042,
+    "lbl:longitude":13.005158,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Kendlersiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Kendlersiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"8fdac26e6bce694a686c581df69be11e",
+    "wof:hierarchy":[],
+    "wof:id":1444828425,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Kendlersiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.005158119962717,
+    47.77904222230038,
+    13.005158119962717,
+    47.77904222230038
+],
+  "geometry": {"coordinates":[13.00515811996272,47.77904222230038],"type":"Point"}
+}

--- a/data/144/482/842/9/1444828429.geojson
+++ b/data/144/482/842/9/1444828429.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444828429,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"12.9903380136,47.7939016735,12.9903380136,47.7939016735",
+    "geom:latitude":47.793902,
+    "geom:longitude":12.990338,
+    "iso:country":"AT",
+    "lbl:latitude":47.793902,
+    "lbl:longitude":12.990338,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Pointing"
+    ],
+    "name:eng_x_preferred":[
+        "Pointing"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"1df0bed33ae6a02163fecc9677f94e5e",
+    "wof:hierarchy":[],
+    "wof:id":1444828429,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Pointing",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    12.990338013629,
+    47.79390167349949,
+    12.990338013629,
+    47.79390167349949
+],
+  "geometry": {"coordinates":[12.990338013629,47.79390167349949],"type":"Point"}
+}

--- a/data/144/482/842/9/1444828429.geojson
+++ b/data/144/482/842/9/1444828429.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        101754161,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"1df0bed33ae6a02163fecc9677f94e5e",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":101754161,
+            "neighbourhood_id":1444828429,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444828429,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566336714,
     "wof:name":"Pointing",
-    "wof:parent_id":-1,
+    "wof:parent_id":101754161,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/483/152/5/1444831525.geojson
+++ b/data/144/483/152/5/1444831525.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"9fb8a033418d258898c19fc442680583",
-    "wof:hierarchy":[],
+    "wof:geomhash":"197ebfa896947ae945d4f59682b842ef",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831525,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831525,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340915,
     "wof:name":"Andritz",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.423674994378544,
-    47.105108701817194,
-    15.423674994378544,
-    47.105108701817194
+    15.42367499437854,
+    47.10510870181719,
+    15.42367499437854,
+    47.10510870181719
 ],
   "geometry": {"coordinates":[15.42367499437854,47.10510870181719],"type":"Point"}
 }

--- a/data/144/483/152/5/1444831525.geojson
+++ b/data/144/483/152/5/1444831525.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831525,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4236749944,47.1051087018,15.4236749944,47.1051087018",
+    "geom:latitude":47.105109,
+    "geom:longitude":15.423675,
+    "iso:country":"AT",
+    "lbl:latitude":47.105109,
+    "lbl:longitude":15.423675,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Andritz"
+    ],
+    "name:eng_x_preferred":[
+        "Andritz"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"9fb8a033418d258898c19fc442680583",
+    "wof:hierarchy":[],
+    "wof:id":1444831525,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Andritz",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.423674994378544,
+    47.105108701817194,
+    15.423674994378544,
+    47.105108701817194
+],
+  "geometry": {"coordinates":[15.42367499437854,47.10510870181719],"type":"Point"}
+}

--- a/data/144/483/153/5/1444831535.geojson
+++ b/data/144/483/153/5/1444831535.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831535,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4904940819,47.1070028231,15.4904940819,47.1070028231",
+    "geom:latitude":47.107003,
+    "geom:longitude":15.490494,
+    "iso:country":"AT",
+    "lbl:latitude":47.107003,
+    "lbl:longitude":15.490494,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Mariatrost"
+    ],
+    "name:eng_x_preferred":[
+        "Mariatrost"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"efa6677af7d7bb56bd0d868f3a4b38ac",
+    "wof:hierarchy":[],
+    "wof:id":1444831535,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Mariatrost",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.49049408191936,
+    47.107002823079824,
+    15.49049408191936,
+    47.107002823079824
+],
+  "geometry": {"coordinates":[15.49049408191936,47.10700282307982],"type":"Point"}
+}

--- a/data/144/483/153/5/1444831535.geojson
+++ b/data/144/483/153/5/1444831535.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"efa6677af7d7bb56bd0d868f3a4b38ac",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f25b85c296e14ee0fb68e9451f6801e3",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831535,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831535,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340918,
     "wof:name":"Mariatrost",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -46,9 +63,9 @@
 },
   "bbox": [
     15.49049408191936,
-    47.107002823079824,
+    47.10700282307982,
     15.49049408191936,
-    47.107002823079824
+    47.10700282307982
 ],
   "geometry": {"coordinates":[15.49049408191936,47.10700282307982],"type":"Point"}
 }

--- a/data/144/483/154/5/1444831545.geojson
+++ b/data/144/483/154/5/1444831545.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831545,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4961663075,47.0886070561,15.4961663075,47.0886070561",
+    "geom:latitude":47.088607,
+    "geom:longitude":15.496166,
+    "iso:country":"AT",
+    "lbl:latitude":47.088607,
+    "lbl:longitude":15.496166,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Ries"
+    ],
+    "name:eng_x_preferred":[
+        "Ries"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"1bfb8766cab4eb369f59258303b85002",
+    "wof:hierarchy":[],
+    "wof:id":1444831545,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Ries",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.496166307528515,
+    47.08860705610721,
+    15.496166307528515,
+    47.08860705610721
+],
+  "geometry": {"coordinates":[15.49616630752852,47.08860705610721],"type":"Point"}
+}

--- a/data/144/483/154/5/1444831545.geojson
+++ b/data/144/483/154/5/1444831545.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"1bfb8766cab4eb369f59258303b85002",
-    "wof:hierarchy":[],
+    "wof:geomhash":"02a3762c97922fbce8b42747ad5ca402",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831545,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831545,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340919,
     "wof:name":"Ries",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.496166307528515,
+    15.49616630752852,
     47.08860705610721,
-    15.496166307528515,
+    15.49616630752852,
     47.08860705610721
 ],
   "geometry": {"coordinates":[15.49616630752852,47.08860705610721],"type":"Point"}

--- a/data/144/483/155/7/1444831557.geojson
+++ b/data/144/483/155/7/1444831557.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831557,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4345372574,47.0847144132,15.4345372574,47.0847144132",
+    "geom:latitude":47.084714,
+    "geom:longitude":15.434537,
+    "iso:country":"AT",
+    "lbl:latitude":47.084714,
+    "lbl:longitude":15.434537,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Geidorf"
+    ],
+    "name:eng_x_preferred":[
+        "Geidorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"9940d858d6b2936723369e61de82f584",
+    "wof:hierarchy":[],
+    "wof:id":1444831557,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Geidorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.434537257389977,
+    47.084714413249415,
+    15.434537257389977,
+    47.084714413249415
+],
+  "geometry": {"coordinates":[15.43453725738998,47.08471441324942],"type":"Point"}
+}

--- a/data/144/483/155/7/1444831557.geojson
+++ b/data/144/483/155/7/1444831557.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"9940d858d6b2936723369e61de82f584",
-    "wof:hierarchy":[],
+    "wof:geomhash":"478869db6d744762e59e54389dad7a32",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831557,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831557,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340919,
     "wof:name":"Geidorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.434537257389977,
-    47.084714413249415,
-    15.434537257389977,
-    47.084714413249415
+    15.43453725738998,
+    47.08471441324942,
+    15.43453725738998,
+    47.08471441324942
 ],
   "geometry": {"coordinates":[15.43453725738998,47.08471441324942],"type":"Point"}
 }

--- a/data/144/483/156/7/1444831567.geojson
+++ b/data/144/483/156/7/1444831567.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"03c23cf6c79bf6171878021e3a76c8c4",
-    "wof:hierarchy":[],
+    "wof:geomhash":"0f30520f98e35d8e1037482699804426",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831567,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831567,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340920,
     "wof:name":"Goesting",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.405952354728317,
+    15.40595235472832,
     47.09257725797204,
-    15.405952354728317,
+    15.40595235472832,
     47.09257725797204
 ],
   "geometry": {"coordinates":[15.40595235472832,47.09257725797204],"type":"Point"}

--- a/data/144/483/156/7/1444831567.geojson
+++ b/data/144/483/156/7/1444831567.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831567,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4059523547,47.092577258,15.4059523547,47.092577258",
+    "geom:latitude":47.092577,
+    "geom:longitude":15.405952,
+    "iso:country":"AT",
+    "lbl:latitude":47.092577,
+    "lbl:longitude":15.405952,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "G\u00f6sting"
+    ],
+    "name:eng_x_preferred":[
+        "Goesting"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"03c23cf6c79bf6171878021e3a76c8c4",
+    "wof:hierarchy":[],
+    "wof:id":1444831567,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Goesting",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.405952354728317,
+    47.09257725797204,
+    15.405952354728317,
+    47.09257725797204
+],
+  "geometry": {"coordinates":[15.40595235472832,47.09257725797204],"type":"Point"}
+}

--- a/data/144/483/157/9/1444831579.geojson
+++ b/data/144/483/157/9/1444831579.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831579,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4213882022,47.0765389373,15.4213882022,47.0765389373",
+    "geom:latitude":47.076539,
+    "geom:longitude":15.421388,
+    "iso:country":"AT",
+    "lbl:latitude":47.076539,
+    "lbl:longitude":15.421388,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Lend"
+    ],
+    "name:eng_x_preferred":[
+        "Lend"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"a5adfc89ff52fa75a7a38115f3afeeed",
+    "wof:hierarchy":[],
+    "wof:id":1444831579,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Lend",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.421388202165613,
+    47.07653893730888,
+    15.421388202165613,
+    47.07653893730888
+],
+  "geometry": {"coordinates":[15.42138820216561,47.07653893730888],"type":"Point"}
+}

--- a/data/144/483/157/9/1444831579.geojson
+++ b/data/144/483/157/9/1444831579.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"a5adfc89ff52fa75a7a38115f3afeeed",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6340ea91381fad827f643f398d4863bd",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831579,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831579,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340923,
     "wof:name":"Lend",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.421388202165613,
+    15.42138820216561,
     47.07653893730888,
-    15.421388202165613,
+    15.42138820216561,
     47.07653893730888
 ],
   "geometry": {"coordinates":[15.42138820216561,47.07653893730888],"type":"Point"}

--- a/data/144/483/159/1/1444831591.geojson
+++ b/data/144/483/159/1/1444831591.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831591,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4391108418,47.0721002964,15.4391108418,47.0721002964",
+    "geom:latitude":47.0721,
+    "geom:longitude":15.439111,
+    "iso:country":"AT",
+    "lbl:latitude":47.0721,
+    "lbl:longitude":15.439111,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Innere Stadt"
+    ],
+    "name:eng_x_preferred":[
+        "Innere Stadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"da16f7134b1dac5747d8796aa75c3e76",
+    "wof:hierarchy":[],
+    "wof:id":1444831591,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Innere Stadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.439110841815841,
+    47.072100296437846,
+    15.439110841815841,
+    47.072100296437846
+],
+  "geometry": {"coordinates":[15.43911084181584,47.07210029643785],"type":"Point"}
+}

--- a/data/144/483/159/1/1444831591.geojson
+++ b/data/144/483/159/1/1444831591.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"da16f7134b1dac5747d8796aa75c3e76",
-    "wof:hierarchy":[],
+    "wof:geomhash":"196f4df2618a3198250e2213cbf1aee0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831591,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831591,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340924,
     "wof:name":"Innere Stadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.439110841815841,
-    47.072100296437846,
-    15.439110841815841,
-    47.072100296437846
+    15.43911084181584,
+    47.07210029643785,
+    15.43911084181584,
+    47.07210029643785
 ],
   "geometry": {"coordinates":[15.43911084181584,47.07210029643785],"type":"Point"}
 }

--- a/data/144/483/159/5/1444831595.geojson
+++ b/data/144/483/159/5/1444831595.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"d1f0393c127146bb14eba8e20fd10b48",
-    "wof:hierarchy":[],
+    "wof:geomhash":"16d21661e8dcb6af5e2efd7863ed03b7",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831595,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831595,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340924,
     "wof:name":"Waltendorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.472040649682071,
+    15.47204064968207,
     47.06773916642804,
-    15.472040649682071,
+    15.47204064968207,
     47.06773916642804
 ],
   "geometry": {"coordinates":[15.47204064968207,47.06773916642804],"type":"Point"}

--- a/data/144/483/159/5/1444831595.geojson
+++ b/data/144/483/159/5/1444831595.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831595,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4720406497,47.0677391664,15.4720406497,47.0677391664",
+    "geom:latitude":47.067739,
+    "geom:longitude":15.472041,
+    "iso:country":"AT",
+    "lbl:latitude":47.067739,
+    "lbl:longitude":15.472041,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Waltendorf"
+    ],
+    "name:eng_x_preferred":[
+        "Waltendorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"d1f0393c127146bb14eba8e20fd10b48",
+    "wof:hierarchy":[],
+    "wof:id":1444831595,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Waltendorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.472040649682071,
+    47.06773916642804,
+    15.472040649682071,
+    47.06773916642804
+],
+  "geometry": {"coordinates":[15.47204064968207,47.06773916642804],"type":"Point"}
+}

--- a/data/144/483/160/9/1444831609.geojson
+++ b/data/144/483/160/9/1444831609.geojson
@@ -32,15 +32,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"90f74953a1903cce1b68e321835e9f60",
-    "wof:hierarchy":[],
+    "wof:geomhash":"43ca166a59702f3d161ab8a8f24b4509",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831609,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831609,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340925,
     "wof:name":"Sankt Leonhard",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -48,9 +65,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.461978763945169,
+    15.46197876394517,
     47.07630533384838,
-    15.461978763945169,
+    15.46197876394517,
     47.07630533384838
 ],
   "geometry": {"coordinates":[15.46197876394517,47.07630533384838],"type":"Point"}

--- a/data/144/483/160/9/1444831609.geojson
+++ b/data/144/483/160/9/1444831609.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444831609,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4619787639,47.0763053338,15.4619787639,47.0763053338",
+    "geom:latitude":47.076305,
+    "geom:longitude":15.461979,
+    "iso:country":"AT",
+    "lbl:latitude":47.076305,
+    "lbl:longitude":15.461979,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Sankt Leonhard"
+    ],
+    "name:deu_x_variant":[
+        "St. Leonhard"
+    ],
+    "name:eng_x_preferred":[
+        "Sankt Leonhard"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"90f74953a1903cce1b68e321835e9f60",
+    "wof:hierarchy":[],
+    "wof:id":1444831609,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Sankt Leonhard",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.461978763945169,
+    47.07630533384838,
+    15.461978763945169,
+    47.07630533384838
+],
+  "geometry": {"coordinates":[15.46197876394517,47.07630533384838],"type":"Point"}
+}

--- a/data/144/483/162/1/1444831621.geojson
+++ b/data/144/483/162/1/1444831621.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444831621,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4725551779,47.0551989299,15.4725551779,47.0551989299",
+    "geom:latitude":47.055199,
+    "geom:longitude":15.472555,
+    "iso:country":"AT",
+    "lbl:latitude":47.055199,
+    "lbl:longitude":15.472555,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Sankt Peter"
+    ],
+    "name:deu_x_variant":[
+        "St. Peter"
+    ],
+    "name:eng_x_preferred":[
+        "Sankt Peter"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"71f7ef488cab9583b56961eeb5ca77f3",
+    "wof:hierarchy":[],
+    "wof:id":1444831621,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Sankt Peter",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.472555177929983,
+    47.055198929875175,
+    15.472555177929983,
+    47.055198929875175
+],
+  "geometry": {"coordinates":[15.47255517792998,47.05519892987517],"type":"Point"}
+}

--- a/data/144/483/162/1/1444831621.geojson
+++ b/data/144/483/162/1/1444831621.geojson
@@ -32,15 +32,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"71f7ef488cab9583b56961eeb5ca77f3",
-    "wof:hierarchy":[],
+    "wof:geomhash":"fb926a0535dde9663741fbd4f3a69a9b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831621,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831621,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340928,
     "wof:name":"Sankt Peter",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -48,10 +65,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.472555177929983,
-    47.055198929875175,
-    15.472555177929983,
-    47.055198929875175
+    15.47255517792998,
+    47.05519892987517,
+    15.47255517792998,
+    47.05519892987517
 ],
   "geometry": {"coordinates":[15.47255517792998,47.05519892987517],"type":"Point"}
 }

--- a/data/144/483/163/3/1444831633.geojson
+++ b/data/144/483/163/3/1444831633.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"dfa585223f5b5d00e80d2dbe7d8b691c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c892ddc149daa5d3b45929c83f774a31",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831633,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831633,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340929,
     "wof:name":"Jakomini",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.444656312932203,
+    15.4446563129322,
     47.06049578711488,
-    15.444656312932203,
+    15.4446563129322,
     47.06049578711488
 ],
   "geometry": {"coordinates":[15.4446563129322,47.06049578711488],"type":"Point"}

--- a/data/144/483/163/3/1444831633.geojson
+++ b/data/144/483/163/3/1444831633.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831633,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4446563129,47.0604957871,15.4446563129,47.0604957871",
+    "geom:latitude":47.060496,
+    "geom:longitude":15.444656,
+    "iso:country":"AT",
+    "lbl:latitude":47.060496,
+    "lbl:longitude":15.444656,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Jakomini"
+    ],
+    "name:eng_x_preferred":[
+        "Jakomini"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"dfa585223f5b5d00e80d2dbe7d8b691c",
+    "wof:hierarchy":[],
+    "wof:id":1444831633,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Jakomini",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.444656312932203,
+    47.06049578711488,
+    15.444656312932203,
+    47.06049578711488
+],
+  "geometry": {"coordinates":[15.4446563129322,47.06049578711488],"type":"Point"}
+}

--- a/data/144/483/164/5/1444831645.geojson
+++ b/data/144/483/164/5/1444831645.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"a0736b2333edca9f64884b3e85afa4bc",
-    "wof:hierarchy":[],
+    "wof:geomhash":"bad7713d3232fc10df3c983e52fdc741",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831645,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831645,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340929,
     "wof:name":"Gries",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.427162352503267,
-    47.062910356240344,
-    15.427162352503267,
-    47.062910356240344
+    15.42716235250327,
+    47.06291035624034,
+    15.42716235250327,
+    47.06291035624034
 ],
   "geometry": {"coordinates":[15.42716235250327,47.06291035624034],"type":"Point"}
 }

--- a/data/144/483/164/5/1444831645.geojson
+++ b/data/144/483/164/5/1444831645.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831645,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4271623525,47.0629103562,15.4271623525,47.0629103562",
+    "geom:latitude":47.06291,
+    "geom:longitude":15.427162,
+    "iso:country":"AT",
+    "lbl:latitude":47.06291,
+    "lbl:longitude":15.427162,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Gries"
+    ],
+    "name:eng_x_preferred":[
+        "Gries"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"a0736b2333edca9f64884b3e85afa4bc",
+    "wof:hierarchy":[],
+    "wof:id":1444831645,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Gries",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.427162352503267,
+    47.062910356240344,
+    15.427162352503267,
+    47.062910356240344
+],
+  "geometry": {"coordinates":[15.42716235250327,47.06291035624034],"type":"Point"}
+}

--- a/data/144/483/165/7/1444831657.geojson
+++ b/data/144/483/165/7/1444831657.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"bc8b97a2bc6e56c4b8eb0503a19b1caa",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f7cc7de2f4c3bf5737ffb8ea1f5f44ec",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831657,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831657,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340930,
     "wof:name":"Eggenberg",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.400570145067736,
-    47.071735333834674,
-    15.400570145067736,
-    47.071735333834674
+    15.40057014506774,
+    47.07173533383467,
+    15.40057014506774,
+    47.07173533383467
 ],
   "geometry": {"coordinates":[15.40057014506774,47.07173533383467],"type":"Point"}
 }

--- a/data/144/483/165/7/1444831657.geojson
+++ b/data/144/483/165/7/1444831657.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831657,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4005701451,47.0717353338,15.4005701451,47.0717353338",
+    "geom:latitude":47.071735,
+    "geom:longitude":15.40057,
+    "iso:country":"AT",
+    "lbl:latitude":47.071735,
+    "lbl:longitude":15.40057,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Eggenberg"
+    ],
+    "name:eng_x_preferred":[
+        "Eggenberg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"bc8b97a2bc6e56c4b8eb0503a19b1caa",
+    "wof:hierarchy":[],
+    "wof:id":1444831657,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Eggenberg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.400570145067736,
+    47.071735333834674,
+    15.400570145067736,
+    47.071735333834674
+],
+  "geometry": {"coordinates":[15.40057014506774,47.07173533383467],"type":"Point"}
+}

--- a/data/144/483/166/9/1444831669.geojson
+++ b/data/144/483/166/9/1444831669.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"5144aab50b45748ac2b6620f45734712",
-    "wof:hierarchy":[],
+    "wof:geomhash":"db5d2544a49297ef0888d7ce293ae40c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831669,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831669,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340933,
     "wof:name":"Wetzelsdorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.395261601132857,
-    47.056133707622884,
-    15.395261601132857,
-    47.056133707622884
+    15.39526160113286,
+    47.05613370762288,
+    15.39526160113286,
+    47.05613370762288
 ],
   "geometry": {"coordinates":[15.39526160113286,47.05613370762288],"type":"Point"}
 }

--- a/data/144/483/166/9/1444831669.geojson
+++ b/data/144/483/166/9/1444831669.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831669,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.3952616011,47.0561337076,15.3952616011,47.0561337076",
+    "geom:latitude":47.056134,
+    "geom:longitude":15.395262,
+    "iso:country":"AT",
+    "lbl:latitude":47.056134,
+    "lbl:longitude":15.395262,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Wetzelsdorf"
+    ],
+    "name:eng_x_preferred":[
+        "Wetzelsdorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"5144aab50b45748ac2b6620f45734712",
+    "wof:hierarchy":[],
+    "wof:id":1444831669,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Wetzelsdorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.395261601132857,
+    47.056133707622884,
+    15.395261601132857,
+    47.056133707622884
+],
+  "geometry": {"coordinates":[15.39526160113286,47.05613370762288],"type":"Point"}
+}

--- a/data/144/483/167/3/1444831673.geojson
+++ b/data/144/483/167/3/1444831673.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831673,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.3988632989,47.0228611167,15.3988632989,47.0228611167",
+    "geom:latitude":47.022861,
+    "geom:longitude":15.398863,
+    "iso:country":"AT",
+    "lbl:latitude":47.022861,
+    "lbl:longitude":15.398863,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Stra\u00dfgang"
+    ],
+    "name:eng_x_preferred":[
+        "Strassgang"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"a9d9ea8a1ac29584a7df5fecee1d38ee",
+    "wof:hierarchy":[],
+    "wof:id":1444831673,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Strassgang",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.398863298868227,
+    47.02286111666921,
+    15.398863298868227,
+    47.02286111666921
+],
+  "geometry": {"coordinates":[15.39886329886823,47.02286111666921],"type":"Point"}
+}

--- a/data/144/483/167/3/1444831673.geojson
+++ b/data/144/483/167/3/1444831673.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"a9d9ea8a1ac29584a7df5fecee1d38ee",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e3d6babe9fd4d105b64ab26c31bf797a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831673,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831673,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340934,
     "wof:name":"Strassgang",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.398863298868227,
+    15.39886329886823,
     47.02286111666921,
-    15.398863298868227,
+    15.39886329886823,
     47.02286111666921
 ],
   "geometry": {"coordinates":[15.39886329886823,47.02286111666921],"type":"Point"}

--- a/data/144/483/168/9/1444831689.geojson
+++ b/data/144/483/168/9/1444831689.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831689,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4331651821,47.0268362175,15.4331651821,47.0268362175",
+    "geom:latitude":47.026836,
+    "geom:longitude":15.433165,
+    "iso:country":"AT",
+    "lbl:latitude":47.026836,
+    "lbl:longitude":15.433165,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Puntigam"
+    ],
+    "name:eng_x_preferred":[
+        "Puntigam"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"dff8b767fa5dd46c72f4499441da88e5",
+    "wof:hierarchy":[],
+    "wof:id":1444831689,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Puntigam",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.433165182062217,
+    47.026836217479925,
+    15.433165182062217,
+    47.026836217479925
+],
+  "geometry": {"coordinates":[15.43316518206222,47.02683621747993],"type":"Point"}
+}

--- a/data/144/483/168/9/1444831689.geojson
+++ b/data/144/483/168/9/1444831689.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"dff8b767fa5dd46c72f4499441da88e5",
-    "wof:hierarchy":[],
+    "wof:geomhash":"27343608d120ecab9600f2f4670fde25",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831689,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831689,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340934,
     "wof:name":"Puntigam",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.433165182062217,
-    47.026836217479925,
-    15.433165182062217,
-    47.026836217479925
+    15.43316518206222,
+    47.02683621747993,
+    15.43316518206222,
+    47.02683621747993
 ],
   "geometry": {"coordinates":[15.43316518206222,47.02683621747993],"type":"Point"}
 }

--- a/data/144/483/170/3/1444831703.geojson
+++ b/data/144/483/170/3/1444831703.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"9e8e73917cc0c1f5037e0dedd7d43be7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f411f4503d227087c18aa3fca5bbe680",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831703,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831703,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340935,
     "wof:name":"Liebenau",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.448944048331455,
+    15.44894404833146,
     47.04296741133666,
-    15.448944048331455,
+    15.44894404833146,
     47.04296741133666
 ],
   "geometry": {"coordinates":[15.44894404833146,47.04296741133666],"type":"Point"}

--- a/data/144/483/170/3/1444831703.geojson
+++ b/data/144/483/170/3/1444831703.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831703,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4489440483,47.0429674113,15.4489440483,47.0429674113",
+    "geom:latitude":47.042967,
+    "geom:longitude":15.448944,
+    "iso:country":"AT",
+    "lbl:latitude":47.042967,
+    "lbl:longitude":15.448944,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Liebenau"
+    ],
+    "name:eng_x_preferred":[
+        "Liebenau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"9e8e73917cc0c1f5037e0dedd7d43be7",
+    "wof:hierarchy":[],
+    "wof:id":1444831703,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Liebenau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.448944048331455,
+    47.04296741133666,
+    15.448944048331455,
+    47.04296741133666
+],
+  "geometry": {"coordinates":[15.44894404833146,47.04296741133666],"type":"Point"}
+}

--- a/data/144/483/171/5/1444831715.geojson
+++ b/data/144/483/171/5/1444831715.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"f53ff83fbb8a4bc9f22e19bf6c7a91a1",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e02fd1e659a9a6bfabe99de736fa665a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831715,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831715,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340938,
     "wof:name":"Murfeld",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.459206028386983,
-    47.022997522091444,
-    15.459206028386983,
-    47.022997522091444
+    15.45920602838698,
+    47.02299752209144,
+    15.45920602838698,
+    47.02299752209144
 ],
   "geometry": {"coordinates":[15.45920602838698,47.02299752209144],"type":"Point"}
 }

--- a/data/144/483/171/5/1444831715.geojson
+++ b/data/144/483/171/5/1444831715.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831715,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4592060284,47.0229975221,15.4592060284,47.0229975221",
+    "geom:latitude":47.022998,
+    "geom:longitude":15.459206,
+    "iso:country":"AT",
+    "lbl:latitude":47.022998,
+    "lbl:longitude":15.459206,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Murfeld"
+    ],
+    "name:eng_x_preferred":[
+        "Murfeld"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"f53ff83fbb8a4bc9f22e19bf6c7a91a1",
+    "wof:hierarchy":[],
+    "wof:id":1444831715,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Murfeld",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.459206028386983,
+    47.022997522091444,
+    15.459206028386983,
+    47.022997522091444
+],
+  "geometry": {"coordinates":[15.45920602838698,47.02299752209144],"type":"Point"}
+}

--- a/data/144/483/172/5/1444831725.geojson
+++ b/data/144/483/172/5/1444831725.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831725,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.483103007,47.0406882993,15.483103007,47.0406882993",
+    "geom:latitude":47.040688,
+    "geom:longitude":15.483103,
+    "iso:country":"AT",
+    "lbl:latitude":47.040688,
+    "lbl:longitude":15.483103,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Messendorf"
+    ],
+    "name:eng_x_preferred":[
+        "Messendorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"c5530944fae8cd44ffe412a896f804f7",
+    "wof:hierarchy":[],
+    "wof:id":1444831725,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Messendorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.48310300701213,
+    47.04068829934278,
+    15.48310300701213,
+    47.04068829934278
+],
+  "geometry": {"coordinates":[15.48310300701213,47.04068829934278],"type":"Point"}
+}

--- a/data/144/483/172/5/1444831725.geojson
+++ b/data/144/483/172/5/1444831725.geojson
@@ -29,15 +29,33 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101754133,
+        102049709,
+        1175610467
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"c5530944fae8cd44ffe412a896f804f7",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101754133,
+            "neighbourhood_id":1444831725,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831725,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340939,
     "wof:name":"Messendorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610467,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/483/173/7/1444831737.geojson
+++ b/data/144/483/173/7/1444831737.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108839329,
+        85632785,
+        102049709,
+        85681687
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"48b14ca175f5b08c94b9853835b19401",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1198ebb0acde846aedc08e33e2f29566",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":-1,
+            "neighbourhood_id":1444831737,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831737,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340940,
     "wof:name":"Webling",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.389573205503183,
+    15.38957320550318,
     47.03250606959976,
-    15.389573205503183,
+    15.38957320550318,
     47.03250606959976
 ],
   "geometry": {"coordinates":[15.38957320550318,47.03250606959976],"type":"Point"}

--- a/data/144/483/173/7/1444831737.geojson
+++ b/data/144/483/173/7/1444831737.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831737,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.3895732055,47.0325060696,15.3895732055,47.0325060696",
+    "geom:latitude":47.032506,
+    "geom:longitude":15.389573,
+    "iso:country":"AT",
+    "lbl:latitude":47.032506,
+    "lbl:longitude":15.389573,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Webling"
+    ],
+    "name:eng_x_preferred":[
+        "Webling"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"48b14ca175f5b08c94b9853835b19401",
+    "wof:hierarchy":[],
+    "wof:id":1444831737,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Webling",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.389573205503183,
+    47.03250606959976,
+    15.389573205503183,
+    47.03250606959976
+],
+  "geometry": {"coordinates":[15.38957320550318,47.03250606959976],"type":"Point"}
+}

--- a/data/144/483/174/7/1444831747.geojson
+++ b/data/144/483/174/7/1444831747.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444831747,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4099256562,47.1165284261,15.4099256562,47.1165284261",
+    "geom:latitude":47.116528,
+    "geom:longitude":15.409926,
+    "iso:country":"AT",
+    "lbl:latitude":47.116528,
+    "lbl:longitude":15.409926,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Sankt Veit"
+    ],
+    "name:deu_x_variant":[
+        "St. Veit"
+    ],
+    "name:eng_x_preferred":[
+        "Sankt Veit"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"66e9c1bc720f5352bf74920fc183ecb2",
+    "wof:hierarchy":[],
+    "wof:id":1444831747,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Sankt Veit",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.409925656198284,
+    47.116528426109454,
+    15.409925656198284,
+    47.116528426109454
+],
+  "geometry": {"coordinates":[15.40992565619828,47.11652842610945],"type":"Point"}
+}

--- a/data/144/483/174/7/1444831747.geojson
+++ b/data/144/483/174/7/1444831747.geojson
@@ -32,15 +32,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"66e9c1bc720f5352bf74920fc183ecb2",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d3bd1bc2e0f87127eacaedcdb3dd9534",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831747,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831747,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340940,
     "wof:name":"Sankt Veit",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -48,10 +65,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.409925656198284,
-    47.116528426109454,
-    15.409925656198284,
-    47.116528426109454
+    15.40992565619828,
+    47.11652842610945,
+    15.40992565619828,
+    47.11652842610945
 ],
   "geometry": {"coordinates":[15.40992565619828,47.11652842610945],"type":"Point"}
 }

--- a/data/144/483/175/9/1444831759.geojson
+++ b/data/144/483/175/9/1444831759.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831759,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4366472439,47.1184912315,15.4366472439,47.1184912315",
+    "geom:latitude":47.118491,
+    "geom:longitude":15.436647,
+    "iso:country":"AT",
+    "lbl:latitude":47.118491,
+    "lbl:longitude":15.436647,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Neustift"
+    ],
+    "name:eng_x_preferred":[
+        "Neustift"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"f496198b5679c12eb19b130532e22207",
+    "wof:hierarchy":[],
+    "wof:id":1444831759,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Neustift",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.436647243870738,
+    47.11849123149218,
+    15.436647243870738,
+    47.11849123149218
+],
+  "geometry": {"coordinates":[15.43664724387074,47.11849123149218],"type":"Point"}
+}

--- a/data/144/483/175/9/1444831759.geojson
+++ b/data/144/483/175/9/1444831759.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"f496198b5679c12eb19b130532e22207",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9497916bce84228313cf7152bcc66128",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831759,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831759,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340943,
     "wof:name":"Neustift",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.436647243870738,
+    15.43664724387074,
     47.11849123149218,
-    15.436647243870738,
+    15.43664724387074,
     47.11849123149218
 ],
   "geometry": {"coordinates":[15.43664724387074,47.11849123149218],"type":"Point"}

--- a/data/144/483/177/1/1444831771.geojson
+++ b/data/144/483/177/1/1444831771.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"a3c27cadb996beb9fb03b89494a0625b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"eb911ec69e696bc6a96e6139efca564f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831771,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831771,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340944,
     "wof:name":"Foelling",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.497967156396186,
+    15.49796715639619,
     47.11388284776526,
-    15.497967156396186,
+    15.49796715639619,
     47.11388284776526
 ],
   "geometry": {"coordinates":[15.49796715639619,47.11388284776526],"type":"Point"}

--- a/data/144/483/177/1/1444831771.geojson
+++ b/data/144/483/177/1/1444831771.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831771,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4979671564,47.1138828478,15.4979671564,47.1138828478",
+    "geom:latitude":47.113883,
+    "geom:longitude":15.497967,
+    "iso:country":"AT",
+    "lbl:latitude":47.113883,
+    "lbl:longitude":15.497967,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "F\u00f6lling"
+    ],
+    "name:eng_x_preferred":[
+        "Foelling"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"a3c27cadb996beb9fb03b89494a0625b",
+    "wof:hierarchy":[],
+    "wof:id":1444831771,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Foelling",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.497967156396186,
+    47.11388284776526,
+    15.497967156396186,
+    47.11388284776526
+],
+  "geometry": {"coordinates":[15.49796715639619,47.11388284776526],"type":"Point"}
+}

--- a/data/144/483/178/1/1444831781.geojson
+++ b/data/144/483/178/1/1444831781.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831781,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.5035697973,47.0981622879,15.5035697973,47.0981622879",
+    "geom:latitude":47.098162,
+    "geom:longitude":15.50357,
+    "iso:country":"AT",
+    "lbl:latitude":47.098162,
+    "lbl:longitude":15.50357,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Stifting"
+    ],
+    "name:eng_x_preferred":[
+        "Stifting"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"9bf609db4afe2ee54a961f2aa42f9200",
+    "wof:hierarchy":[],
+    "wof:id":1444831781,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Stifting",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.503569797317871,
+    47.098162287918356,
+    15.503569797317871,
+    47.098162287918356
+],
+  "geometry": {"coordinates":[15.50356979731787,47.09816228791836],"type":"Point"}
+}

--- a/data/144/483/178/1/1444831781.geojson
+++ b/data/144/483/178/1/1444831781.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"9bf609db4afe2ee54a961f2aa42f9200",
-    "wof:hierarchy":[],
+    "wof:geomhash":"bf2ff334f5c902a660ac722853371a1b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831781,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831781,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340945,
     "wof:name":"Stifting",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.503569797317871,
-    47.098162287918356,
-    15.503569797317871,
-    47.098162287918356
+    15.50356979731787,
+    47.09816228791836,
+    15.50356979731787,
+    47.09816228791836
 ],
   "geometry": {"coordinates":[15.50356979731787,47.09816228791836],"type":"Point"}
 }

--- a/data/144/483/179/5/1444831795.geojson
+++ b/data/144/483/179/5/1444831795.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831795,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4923611031,47.0808330142,15.4923611031,47.0808330142",
+    "geom:latitude":47.080833,
+    "geom:longitude":15.492361,
+    "iso:country":"AT",
+    "lbl:latitude":47.080833,
+    "lbl:longitude":15.492361,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Ragnitz"
+    ],
+    "name:eng_x_preferred":[
+        "Ragnitz"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"0fc00d7d09e68a94245071ffb1d00824",
+    "wof:hierarchy":[],
+    "wof:id":1444831795,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Ragnitz",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.492361103107227,
+    47.080833014223,
+    15.492361103107227,
+    47.080833014223
+],
+  "geometry": {"coordinates":[15.49236110310723,47.080833014223],"type":"Point"}
+}

--- a/data/144/483/179/5/1444831795.geojson
+++ b/data/144/483/179/5/1444831795.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"0fc00d7d09e68a94245071ffb1d00824",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d8daf24564cd3692763ded4cff986b84",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831795,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831795,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340945,
     "wof:name":"Ragnitz",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.492361103107227,
+    15.49236110310723,
     47.080833014223,
-    15.492361103107227,
+    15.49236110310723,
     47.080833014223
 ],
   "geometry": {"coordinates":[15.49236110310723,47.080833014223],"type":"Point"}

--- a/data/144/483/180/5/1444831805.geojson
+++ b/data/144/483/180/5/1444831805.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"6dc0519793467cebeec204d4efcee4b9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"59eab9d66d0db03ac900fbf93df4caf5",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831805,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831805,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340948,
     "wof:name":"Engelsdorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -46,9 +63,9 @@
 },
   "bbox": [
     15.46569833155762,
-    47.030490712712776,
+    47.03049071271278,
     15.46569833155762,
-    47.030490712712776
+    47.03049071271278
 ],
   "geometry": {"coordinates":[15.46569833155762,47.03049071271278],"type":"Point"}
 }

--- a/data/144/483/180/5/1444831805.geojson
+++ b/data/144/483/180/5/1444831805.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831805,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4656983316,47.0304907127,15.4656983316,47.0304907127",
+    "geom:latitude":47.030491,
+    "geom:longitude":15.465698,
+    "iso:country":"AT",
+    "lbl:latitude":47.030491,
+    "lbl:longitude":15.465698,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Engelsdorf"
+    ],
+    "name:eng_x_preferred":[
+        "Engelsdorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"6dc0519793467cebeec204d4efcee4b9",
+    "wof:hierarchy":[],
+    "wof:id":1444831805,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Engelsdorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.46569833155762,
+    47.030490712712776,
+    15.46569833155762,
+    47.030490712712776
+],
+  "geometry": {"coordinates":[15.46569833155762,47.03049071271278],"type":"Point"}
+}

--- a/data/144/483/181/3/1444831813.geojson
+++ b/data/144/483/181/3/1444831813.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831813,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4715912798,47.0179493388,15.4715912798,47.0179493388",
+    "geom:latitude":47.017949,
+    "geom:longitude":15.471591,
+    "iso:country":"AT",
+    "lbl:latitude":47.017949,
+    "lbl:longitude":15.471591,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Thondorf"
+    ],
+    "name:eng_x_preferred":[
+        "Thondorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"a9ffdcad9100727ba5dfcf5ed9c7e4c7",
+    "wof:hierarchy":[],
+    "wof:id":1444831813,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Thondorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.471591279821496,
+    47.017949338839735,
+    15.471591279821496,
+    47.017949338839735
+],
+  "geometry": {"coordinates":[15.4715912798215,47.01794933883973],"type":"Point"}
+}

--- a/data/144/483/181/3/1444831813.geojson
+++ b/data/144/483/181/3/1444831813.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"a9ffdcad9100727ba5dfcf5ed9c7e4c7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"663c9025258e28573abebca5a78e1f6d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831813,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831813,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340949,
     "wof:name":"Thondorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.471591279821496,
-    47.017949338839735,
-    15.471591279821496,
-    47.017949338839735
+    15.4715912798215,
+    47.01794933883973,
+    15.4715912798215,
+    47.01794933883973
 ],
   "geometry": {"coordinates":[15.4715912798215,47.01794933883973],"type":"Point"}
 }

--- a/data/144/483/182/5/1444831825.geojson
+++ b/data/144/483/182/5/1444831825.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831825,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4691478622,47.0241714043,15.4691478622,47.0241714043",
+    "geom:latitude":47.024171,
+    "geom:longitude":15.469148,
+    "iso:country":"AT",
+    "lbl:latitude":47.024171,
+    "lbl:longitude":15.469148,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Neudorf"
+    ],
+    "name:eng_x_preferred":[
+        "Neudorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"b69cc0138f3a56fc7610fc08469237db",
+    "wof:hierarchy":[],
+    "wof:id":1444831825,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Neudorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.46914786224867,
+    47.02417140430201,
+    15.46914786224867,
+    47.02417140430201
+],
+  "geometry": {"coordinates":[15.46914786224867,47.02417140430201],"type":"Point"}
+}

--- a/data/144/483/182/5/1444831825.geojson
+++ b/data/144/483/182/5/1444831825.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"b69cc0138f3a56fc7610fc08469237db",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831825,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831825,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340950,
     "wof:name":"Neudorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/483/183/5/1444831835.geojson
+++ b/data/144/483/183/5/1444831835.geojson
@@ -29,15 +29,33 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101754133,
+        102049709,
+        1175610467
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"565e5a7aaa6a42fa3b64b93ab9cd721d",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101754133,
+            "neighbourhood_id":1444831835,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831835,
-    "wof:lastmodified":1566333179,
+    "wof:lastmodified":1566340950,
     "wof:name":"Tiefental",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610467,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/483/183/5/1444831835.geojson
+++ b/data/144/483/183/5/1444831835.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831835,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4919291379,47.036123574,15.4919291379,47.036123574",
+    "geom:latitude":47.036124,
+    "geom:longitude":15.491929,
+    "iso:country":"AT",
+    "lbl:latitude":47.036124,
+    "lbl:longitude":15.491929,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Tiefental"
+    ],
+    "name:eng_x_preferred":[
+        "Tiefental"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"565e5a7aaa6a42fa3b64b93ab9cd721d",
+    "wof:hierarchy":[],
+    "wof:id":1444831835,
+    "wof:lastmodified":1566333179,
+    "wof:name":"Tiefental",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.49192913785414,
+    47.03612357396586,
+    15.49192913785414,
+    47.03612357396586
+],
+  "geometry": {"coordinates":[15.49192913785414,47.03612357396586],"type":"Point"}
+}

--- a/data/144/483/184/7/1444831847.geojson
+++ b/data/144/483/184/7/1444831847.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831847,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4419828081,47.0328418923,15.4419828081,47.0328418923",
+    "geom:latitude":47.032842,
+    "geom:longitude":15.441983,
+    "iso:country":"AT",
+    "lbl:latitude":47.032842,
+    "lbl:longitude":15.441983,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Rudersdorf"
+    ],
+    "name:eng_x_preferred":[
+        "Rudersdorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"b1953cde0b515f6e8a078de9bdbd3b23",
+    "wof:hierarchy":[],
+    "wof:id":1444831847,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Rudersdorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.44198280805666,
+    47.0328418923081,
+    15.44198280805666,
+    47.0328418923081
+],
+  "geometry": {"coordinates":[15.44198280805666,47.0328418923081],"type":"Point"}
+}

--- a/data/144/483/184/7/1444831847.geojson
+++ b/data/144/483/184/7/1444831847.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"b1953cde0b515f6e8a078de9bdbd3b23",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831847,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831847,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340953,
     "wof:name":"Rudersdorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/483/185/9/1444831859.geojson
+++ b/data/144/483/185/9/1444831859.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831859,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.400013518,47.0407273842,15.400013518,47.0407273842",
+    "geom:latitude":47.040727,
+    "geom:longitude":15.400014,
+    "iso:country":"AT",
+    "lbl:latitude":47.040727,
+    "lbl:longitude":15.400014,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Hart"
+    ],
+    "name:eng_x_preferred":[
+        "Hart"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"d21a8f6f879e10cc1e0252c69445dc5b",
+    "wof:hierarchy":[],
+    "wof:id":1444831859,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Hart",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.400013517982229,
+    47.04072738417018,
+    15.400013517982229,
+    47.04072738417018
+],
+  "geometry": {"coordinates":[15.40001351798223,47.04072738417018],"type":"Point"}
+}

--- a/data/144/483/185/9/1444831859.geojson
+++ b/data/144/483/185/9/1444831859.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"d21a8f6f879e10cc1e0252c69445dc5b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d0e8730572a74b79dbcdfa237953cae1",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831859,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831859,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340954,
     "wof:name":"Hart",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.400013517982229,
+    15.40001351798223,
     47.04072738417018,
-    15.400013517982229,
+    15.40001351798223,
     47.04072738417018
 ],
   "geometry": {"coordinates":[15.40001351798223,47.04072738417018],"type":"Point"}

--- a/data/144/483/186/5/1444831865.geojson
+++ b/data/144/483/186/5/1444831865.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"a11250474a973732222aa0471b3e2ee6",
-    "wof:hierarchy":[],
+    "wof:geomhash":"31a2e1ad6c08684f12535c8d24e36014",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831865,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831865,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340955,
     "wof:name":"Krottendorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.396923313404828,
+    15.39692331340483,
     47.04885654694899,
-    15.396923313404828,
+    15.39692331340483,
     47.04885654694899
 ],
   "geometry": {"coordinates":[15.39692331340483,47.04885654694899],"type":"Point"}

--- a/data/144/483/186/5/1444831865.geojson
+++ b/data/144/483/186/5/1444831865.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831865,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.3969233134,47.0488565469,15.3969233134,47.0488565469",
+    "geom:latitude":47.048857,
+    "geom:longitude":15.396923,
+    "iso:country":"AT",
+    "lbl:latitude":47.048856,
+    "lbl:longitude":15.396923,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Krottendorf"
+    ],
+    "name:eng_x_preferred":[
+        "Krottendorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"a11250474a973732222aa0471b3e2ee6",
+    "wof:hierarchy":[],
+    "wof:id":1444831865,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Krottendorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.396923313404828,
+    47.04885654694899,
+    15.396923313404828,
+    47.04885654694899
+],
+  "geometry": {"coordinates":[15.39692331340483,47.04885654694899],"type":"Point"}
+}

--- a/data/144/483/188/1/1444831881.geojson
+++ b/data/144/483/188/1/1444831881.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831881,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.3775915685,47.0322541071,15.3775915685,47.0322541071",
+    "geom:latitude":47.032254,
+    "geom:longitude":15.377592,
+    "iso:country":"AT",
+    "lbl:latitude":47.032254,
+    "lbl:longitude":15.377591,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Kehlberg"
+    ],
+    "name:eng_x_preferred":[
+        "Kehlberg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"a1702b3ea098a099278ca96029b381bc",
+    "wof:hierarchy":[],
+    "wof:id":1444831881,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Kehlberg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.377591568490406,
+    47.03225410711986,
+    15.377591568490406,
+    47.03225410711986
+],
+  "geometry": {"coordinates":[15.37759156849041,47.03225410711986],"type":"Point"}
+}

--- a/data/144/483/188/1/1444831881.geojson
+++ b/data/144/483/188/1/1444831881.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108839329,
+        85632785,
+        102049709,
+        85681687
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"a1702b3ea098a099278ca96029b381bc",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d542915e56485dbdd19353925012183c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":-1,
+            "neighbourhood_id":1444831881,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831881,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340956,
     "wof:name":"Kehlberg",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.377591568490406,
+    15.37759156849041,
     47.03225410711986,
-    15.377591568490406,
+    15.37759156849041,
     47.03225410711986
 ],
   "geometry": {"coordinates":[15.37759156849041,47.03225410711986],"type":"Point"}

--- a/data/144/483/189/5/1444831895.geojson
+++ b/data/144/483/189/5/1444831895.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831895,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4919650705,47.0418782731,15.4919650705,47.0418782731",
+    "geom:latitude":47.041878,
+    "geom:longitude":15.491965,
+    "iso:country":"AT",
+    "lbl:latitude":47.041878,
+    "lbl:longitude":15.491965,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Messendorfberg"
+    ],
+    "name:eng_x_preferred":[
+        "Messendorfberg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"1a509b0c427fd248853cb4db04f9044b",
+    "wof:hierarchy":[],
+    "wof:id":1444831895,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Messendorfberg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.49196507046551,
+    47.04187827308107,
+    15.49196507046551,
+    47.04187827308107
+],
+  "geometry": {"coordinates":[15.49196507046551,47.04187827308107],"type":"Point"}
+}

--- a/data/144/483/189/5/1444831895.geojson
+++ b/data/144/483/189/5/1444831895.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"1a509b0c427fd248853cb4db04f9044b",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831895,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831895,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340959,
     "wof:name":"Messendorfberg",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/483/190/1/1444831901.geojson
+++ b/data/144/483/190/1/1444831901.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"6aa049ceb622b617a9823807c65883cb",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e779fcbda4bca79cd9fc31a6132186b2",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831901,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831901,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340959,
     "wof:name":"Peterstal",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.485533133031158,
-    47.058746989825025,
-    15.485533133031158,
-    47.058746989825025
+    15.48553313303116,
+    47.05874698982502,
+    15.48553313303116,
+    47.05874698982502
 ],
   "geometry": {"coordinates":[15.48553313303116,47.05874698982502],"type":"Point"}
 }

--- a/data/144/483/190/1/1444831901.geojson
+++ b/data/144/483/190/1/1444831901.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831901,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.485533133,47.0587469898,15.485533133,47.0587469898",
+    "geom:latitude":47.058747,
+    "geom:longitude":15.485533,
+    "iso:country":"AT",
+    "lbl:latitude":47.058747,
+    "lbl:longitude":15.485533,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Peterstal"
+    ],
+    "name:eng_x_preferred":[
+        "Peterstal"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"6aa049ceb622b617a9823807c65883cb",
+    "wof:hierarchy":[],
+    "wof:id":1444831901,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Peterstal",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.485533133031158,
+    47.058746989825025,
+    15.485533133031158,
+    47.058746989825025
+],
+  "geometry": {"coordinates":[15.48553313303116,47.05874698982502],"type":"Point"}
+}

--- a/data/144/483/191/3/1444831913.geojson
+++ b/data/144/483/191/3/1444831913.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"525ccc24f2d6b6c101099f981a2eb89e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1712fe0a5b811428e0b14f9fb1c8d0bf",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831913,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831913,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340960,
     "wof:name":"Petersbergen",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -46,9 +63,9 @@
 },
   "bbox": [
     15.49810954700894,
-    47.059432398093904,
+    47.0594323980939,
     15.49810954700894,
-    47.059432398093904
+    47.0594323980939
 ],
   "geometry": {"coordinates":[15.49810954700894,47.0594323980939],"type":"Point"}
 }

--- a/data/144/483/191/3/1444831913.geojson
+++ b/data/144/483/191/3/1444831913.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831913,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.498109547,47.0594323981,15.498109547,47.0594323981",
+    "geom:latitude":47.059432,
+    "geom:longitude":15.49811,
+    "iso:country":"AT",
+    "lbl:latitude":47.059432,
+    "lbl:longitude":15.498109,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Petersbergen"
+    ],
+    "name:eng_x_preferred":[
+        "Petersbergen"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"525ccc24f2d6b6c101099f981a2eb89e",
+    "wof:hierarchy":[],
+    "wof:id":1444831913,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Petersbergen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.49810954700894,
+    47.059432398093904,
+    15.49810954700894,
+    47.059432398093904
+],
+  "geometry": {"coordinates":[15.49810954700894,47.0594323980939],"type":"Point"}
+}

--- a/data/144/483/192/7/1444831927.geojson
+++ b/data/144/483/192/7/1444831927.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831927,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.3917400342,47.0644992502,15.3917400342,47.0644992502",
+    "geom:latitude":47.064499,
+    "geom:longitude":15.39174,
+    "iso:country":"AT",
+    "lbl:latitude":47.064499,
+    "lbl:longitude":15.39174,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Baiersdorf"
+    ],
+    "name:eng_x_preferred":[
+        "Baiersdorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"66dd7c629e91fcb2d2909faf6fb0ad28",
+    "wof:hierarchy":[],
+    "wof:id":1444831927,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Baiersdorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.391740034215415,
+    47.06449925016694,
+    15.391740034215415,
+    47.06449925016694
+],
+  "geometry": {"coordinates":[15.39174003421541,47.06449925016694],"type":"Point"}
+}

--- a/data/144/483/192/7/1444831927.geojson
+++ b/data/144/483/192/7/1444831927.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"66dd7c629e91fcb2d2909faf6fb0ad28",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b8e9d2d6519357d253172799561f5985",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831927,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831927,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340961,
     "wof:name":"Baiersdorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.391740034215415,
+    15.39174003421541,
     47.06449925016694,
-    15.391740034215415,
+    15.39174003421541,
     47.06449925016694
 ],
   "geometry": {"coordinates":[15.39174003421541,47.06449925016694],"type":"Point"}

--- a/data/144/483/193/5/1444831935.geojson
+++ b/data/144/483/193/5/1444831935.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"ac78d88c63afdb62f99e360338bffb6b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a5b916ba133ba304c3af6c3443c6cd14",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831935,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831935,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340964,
     "wof:name":"Algersdorf",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.392458686442717,
+    15.39245868644272,
     47.0786447223657,
-    15.392458686442717,
+    15.39245868644272,
     47.0786447223657
 ],
   "geometry": {"coordinates":[15.39245868644272,47.0786447223657],"type":"Point"}

--- a/data/144/483/193/5/1444831935.geojson
+++ b/data/144/483/193/5/1444831935.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831935,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.3924586864,47.0786447224,15.3924586864,47.0786447224",
+    "geom:latitude":47.078645,
+    "geom:longitude":15.392459,
+    "iso:country":"AT",
+    "lbl:latitude":47.078645,
+    "lbl:longitude":15.392459,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Algersdorf"
+    ],
+    "name:eng_x_preferred":[
+        "Algersdorf"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"ac78d88c63afdb62f99e360338bffb6b",
+    "wof:hierarchy":[],
+    "wof:id":1444831935,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Algersdorf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.392458686442717,
+    47.0786447223657,
+    15.392458686442717,
+    47.0786447223657
+],
+  "geometry": {"coordinates":[15.39245868644272,47.0786447223657],"type":"Point"}
+}

--- a/data/144/483/194/9/1444831949.geojson
+++ b/data/144/483/194/9/1444831949.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"b96d35b7c02192eab2d400e623c96e90",
-    "wof:hierarchy":[],
+    "wof:geomhash":"236fd137637cc55bc342215d80586b9e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831949,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831949,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340964,
     "wof:name":"Ruckerlberg",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.469713800877674,
+    15.46971380087767,
     47.07414207282561,
-    15.469713800877674,
+    15.46971380087767,
     47.07414207282561
 ],
   "geometry": {"coordinates":[15.46971380087767,47.07414207282561],"type":"Point"}

--- a/data/144/483/194/9/1444831949.geojson
+++ b/data/144/483/194/9/1444831949.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831949,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4697138009,47.0741420728,15.4697138009,47.0741420728",
+    "geom:latitude":47.074142,
+    "geom:longitude":15.469714,
+    "iso:country":"AT",
+    "lbl:latitude":47.074142,
+    "lbl:longitude":15.469714,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Ruckerlberg"
+    ],
+    "name:eng_x_preferred":[
+        "Ruckerlberg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"b96d35b7c02192eab2d400e623c96e90",
+    "wof:hierarchy":[],
+    "wof:id":1444831949,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Ruckerlberg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.469713800877674,
+    47.07414207282561,
+    15.469713800877674,
+    47.07414207282561
+],
+  "geometry": {"coordinates":[15.46971380087767,47.07414207282561],"type":"Point"}
+}

--- a/data/144/483/196/7/1444831967.geojson
+++ b/data/144/483/196/7/1444831967.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831967,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.5007595771,47.0792809356,15.5007595771,47.0792809356",
+    "geom:latitude":47.079281,
+    "geom:longitude":15.50076,
+    "iso:country":"AT",
+    "lbl:latitude":47.079281,
+    "lbl:longitude":15.500759,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Haidegg"
+    ],
+    "name:eng_x_preferred":[
+        "Haidegg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"26d77227f3af6185f36aa9f681305226",
+    "wof:hierarchy":[],
+    "wof:id":1444831967,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Haidegg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.500759577097117,
+    47.079280935643204,
+    15.500759577097117,
+    47.079280935643204
+],
+  "geometry": {"coordinates":[15.50075957709712,47.0792809356432],"type":"Point"}
+}

--- a/data/144/483/196/7/1444831967.geojson
+++ b/data/144/483/196/7/1444831967.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"26d77227f3af6185f36aa9f681305226",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7d166ba85c68c8055f16a0ef7f6643f6",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831967,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831967,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340965,
     "wof:name":"Haidegg",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.500759577097117,
-    47.079280935643204,
-    15.500759577097117,
-    47.079280935643204
+    15.50075957709712,
+    47.0792809356432,
+    15.50075957709712,
+    47.0792809356432
 ],
   "geometry": {"coordinates":[15.50075957709712,47.0792809356432],"type":"Point"}
 }

--- a/data/144/483/197/3/1444831973.geojson
+++ b/data/144/483/197/3/1444831973.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831973,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4792718755,47.0842235646,15.4792718755,47.0842235646",
+    "geom:latitude":47.084224,
+    "geom:longitude":15.479272,
+    "iso:country":"AT",
+    "lbl:latitude":47.084224,
+    "lbl:longitude":15.479272,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Goigner"
+    ],
+    "name:eng_x_preferred":[
+        "Goigner"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"fd8bc8bba5f925ff0b24aba3eb0f93c0",
+    "wof:hierarchy":[],
+    "wof:id":1444831973,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Goigner",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.479271875500789,
+    47.08422356463218,
+    15.479271875500789,
+    47.08422356463218
+],
+  "geometry": {"coordinates":[15.47927187550079,47.08422356463218],"type":"Point"}
+}

--- a/data/144/483/197/3/1444831973.geojson
+++ b/data/144/483/197/3/1444831973.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"fd8bc8bba5f925ff0b24aba3eb0f93c0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e220a9c99cc1dac5e1b9ebce91f1e90a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831973,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831973,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340965,
     "wof:name":"Goigner",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.479271875500789,
+    15.47927187550079,
     47.08422356463218,
-    15.479271875500789,
+    15.47927187550079,
     47.08422356463218
 ],
   "geometry": {"coordinates":[15.47927187550079,47.08422356463218],"type":"Point"}

--- a/data/144/483/198/9/1444831989.geojson
+++ b/data/144/483/198/9/1444831989.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108839329,
+        85632785,
+        102049709,
+        85681687
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"34bd18290271a11fb11e60baa27e4ee6",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f2a3299813771e89780aa7ec1e98fd83",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":-1,
+            "neighbourhood_id":1444831989,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831989,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340969,
     "wof:name":"Rohrbach",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,10 +61,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.527852766066394,
-    47.107120058623785,
-    15.527852766066394,
-    47.107120058623785
+    15.52785276606639,
+    47.10712005862379,
+    15.52785276606639,
+    47.10712005862379
 ],
   "geometry": {"coordinates":[15.52785276606639,47.10712005862379],"type":"Point"}
 }

--- a/data/144/483/198/9/1444831989.geojson
+++ b/data/144/483/198/9/1444831989.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831989,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.5278527661,47.1071200586,15.5278527661,47.1071200586",
+    "geom:latitude":47.10712,
+    "geom:longitude":15.527853,
+    "iso:country":"AT",
+    "lbl:latitude":47.10712,
+    "lbl:longitude":15.527853,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Rohrbach"
+    ],
+    "name:eng_x_preferred":[
+        "Rohrbach"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"34bd18290271a11fb11e60baa27e4ee6",
+    "wof:hierarchy":[],
+    "wof:id":1444831989,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Rohrbach",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.527852766066394,
+    47.107120058623785,
+    15.527852766066394,
+    47.107120058623785
+],
+  "geometry": {"coordinates":[15.52785276606639,47.10712005862379],"type":"Point"}
+}

--- a/data/144/483/199/7/1444831997.geojson
+++ b/data/144/483/199/7/1444831997.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"14e20c8168cac61ca857b1b8b6bc2ff8",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444831997,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444831997,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340969,
     "wof:name":"Auf der Ries",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/483/199/7/1444831997.geojson
+++ b/data/144/483/199/7/1444831997.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831997,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.5188696132,47.0942542235,15.5188696132,47.0942542235",
+    "geom:latitude":47.094254,
+    "geom:longitude":15.51887,
+    "iso:country":"AT",
+    "lbl:latitude":47.094254,
+    "lbl:longitude":15.51887,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Auf der Ries"
+    ],
+    "name:eng_x_preferred":[
+        "Auf der Ries"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"14e20c8168cac61ca857b1b8b6bc2ff8",
+    "wof:hierarchy":[],
+    "wof:id":1444831997,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Auf der Ries",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.51886961322512,
+    47.09425422350584,
+    15.51886961322512,
+    47.09425422350584
+],
+  "geometry": {"coordinates":[15.51886961322512,47.09425422350584],"type":"Point"}
+}

--- a/data/144/483/200/9/1444832009.geojson
+++ b/data/144/483/200/9/1444832009.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108839329,
+        85632785,
+        102049709,
+        85681687
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"bf9b83d7224aa4e4654797572ffa0b35",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":-1,
+            "neighbourhood_id":1444832009,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832009,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340970,
     "wof:name":"Eckmichl",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/144/483/200/9/1444832009.geojson
+++ b/data/144/483/200/9/1444832009.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832009,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.506868121,47.1053102241,15.506868121,47.1053102241",
+    "geom:latitude":47.10531,
+    "geom:longitude":15.506868,
+    "iso:country":"AT",
+    "lbl:latitude":47.10531,
+    "lbl:longitude":15.506868,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Eckmichl"
+    ],
+    "name:eng_x_preferred":[
+        "Eckmichl"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"bf9b83d7224aa4e4654797572ffa0b35",
+    "wof:hierarchy":[],
+    "wof:id":1444832009,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Eckmichl",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.50686812102918,
+    47.10531022412214,
+    15.50686812102918,
+    47.10531022412214
+],
+  "geometry": {"coordinates":[15.50686812102918,47.10531022412214],"type":"Point"}
+}

--- a/data/144/483/202/3/1444832023.geojson
+++ b/data/144/483/202/3/1444832023.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832023,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4794156059,47.1016903705,15.4794156059,47.1016903705",
+    "geom:latitude":47.10169,
+    "geom:longitude":15.479416,
+    "iso:country":"AT",
+    "lbl:latitude":47.10169,
+    "lbl:longitude":15.479416,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Rettenbacj=h"
+    ],
+    "name:eng_x_preferred":[
+        "Rettenbacj=h"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"942f7066a95412f2eee23104d9722e28",
+    "wof:hierarchy":[],
+    "wof:id":1444832023,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Rettenbacj=h",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.479415605946247,
+    47.10169037051683,
+    15.479415605946247,
+    47.10169037051683
+],
+  "geometry": {"coordinates":[15.47941560594625,47.10169037051683],"type":"Point"}
+}

--- a/data/144/483/202/3/1444832023.geojson
+++ b/data/144/483/202/3/1444832023.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"942f7066a95412f2eee23104d9722e28",
-    "wof:hierarchy":[],
+    "wof:geomhash":"5b3b976d63f4352b9609b2555768f23d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444832023,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832023,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340971,
     "wof:name":"Rettenbacj=h",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.479415605946247,
+    15.47941560594625,
     47.10169037051683,
-    15.479415605946247,
+    15.47941560594625,
     47.10169037051683
 ],
   "geometry": {"coordinates":[15.47941560594625,47.10169037051683],"type":"Point"}

--- a/data/144/483/203/1/1444832031.geojson
+++ b/data/144/483/203/1/1444832031.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108839329,
+        85632785,
+        102049709,
+        85681687
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"6a740adbc532e38deec64b6105263a2d",
-    "wof:hierarchy":[],
+    "wof:geomhash":"04006fa78bd93409b835b4b4bc3f13b9",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":-1,
+            "neighbourhood_id":1444832031,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832031,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340974,
     "wof:name":"Teichhof",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.487392645669297,
+    15.4873926456693,
     47.09953790844372,
-    15.487392645669297,
+    15.4873926456693,
     47.09953790844372
 ],
   "geometry": {"coordinates":[15.4873926456693,47.09953790844372],"type":"Point"}

--- a/data/144/483/203/1/1444832031.geojson
+++ b/data/144/483/203/1/1444832031.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832031,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4873926457,47.0995379084,15.4873926457,47.0995379084",
+    "geom:latitude":47.099538,
+    "geom:longitude":15.487393,
+    "iso:country":"AT",
+    "lbl:latitude":47.099538,
+    "lbl:longitude":15.487393,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Teichhof"
+    ],
+    "name:eng_x_preferred":[
+        "Teichhof"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"6a740adbc532e38deec64b6105263a2d",
+    "wof:hierarchy":[],
+    "wof:id":1444832031,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Teichhof",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.487392645669297,
+    47.09953790844372,
+    15.487392645669297,
+    47.09953790844372
+],
+  "geometry": {"coordinates":[15.4873926456693,47.09953790844372],"type":"Point"}
+}

--- a/data/144/483/204/7/1444832047.geojson
+++ b/data/144/483/204/7/1444832047.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108839329,
+        85632785,
+        102049709,
+        85681687
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"9e235e9448b503aa2f0a01366d17cb57",
-    "wof:hierarchy":[],
+    "wof:geomhash":"be84be35e42f5915e0f8fa581b292243",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":-1,
+            "neighbourhood_id":1444832047,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832047,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340974,
     "wof:name":"Tullhof",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.486530262996533,
+    15.48653026299653,
     47.11592378107544,
-    15.486530262996533,
+    15.48653026299653,
     47.11592378107544
 ],
   "geometry": {"coordinates":[15.48653026299653,47.11592378107544],"type":"Point"}

--- a/data/144/483/204/7/1444832047.geojson
+++ b/data/144/483/204/7/1444832047.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832047,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.486530263,47.1159237811,15.486530263,47.1159237811",
+    "geom:latitude":47.115924,
+    "geom:longitude":15.48653,
+    "iso:country":"AT",
+    "lbl:latitude":47.115924,
+    "lbl:longitude":15.48653,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Tullhof"
+    ],
+    "name:eng_x_preferred":[
+        "Tullhof"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"9e235e9448b503aa2f0a01366d17cb57",
+    "wof:hierarchy":[],
+    "wof:id":1444832047,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Tullhof",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.486530262996533,
+    47.11592378107544,
+    15.486530262996533,
+    47.11592378107544
+],
+  "geometry": {"coordinates":[15.48653026299653,47.11592378107544],"type":"Point"}
+}

--- a/data/144/483/206/1/1444832061.geojson
+++ b/data/144/483/206/1/1444832061.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832061,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4606587828,47.0908782614,15.4606587828,47.0908782614",
+    "geom:latitude":47.090878,
+    "geom:longitude":15.460659,
+    "iso:country":"AT",
+    "lbl:latitude":47.090878,
+    "lbl:longitude":15.460659,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Kroisbach"
+    ],
+    "name:eng_x_preferred":[
+        "Kroisbach"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"76dbd2425a1f8b6470f776da43255ab8",
+    "wof:hierarchy":[],
+    "wof:id":1444832061,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Kroisbach",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.460658782813667,
+    47.09087826142386,
+    15.460658782813667,
+    47.09087826142386
+],
+  "geometry": {"coordinates":[15.46065878281367,47.09087826142386],"type":"Point"}
+}

--- a/data/144/483/206/1/1444832061.geojson
+++ b/data/144/483/206/1/1444832061.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"76dbd2425a1f8b6470f776da43255ab8",
-    "wof:hierarchy":[],
+    "wof:geomhash":"eb560f3ecb35498758b74a485cc9354e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444832061,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832061,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340975,
     "wof:name":"Kroisbach",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.460658782813667,
+    15.46065878281367,
     47.09087826142386,
-    15.460658782813667,
+    15.46065878281367,
     47.09087826142386
 ],
   "geometry": {"coordinates":[15.46065878281367,47.09087826142386],"type":"Point"}

--- a/data/144/483/207/1/1444832071.geojson
+++ b/data/144/483/207/1/1444832071.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"30c40656984f5f3dfcca1f9aac4a7318",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d3ba9d550471144dc6800041b2527e3e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444832071,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832071,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340976,
     "wof:name":"Mariagruen",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.451819360417852,
+    15.45181936041785,
     47.09909762139033,
-    15.451819360417852,
+    15.45181936041785,
     47.09909762139033
 ],
   "geometry": {"coordinates":[15.45181936041785,47.09909762139033],"type":"Point"}

--- a/data/144/483/207/1/1444832071.geojson
+++ b/data/144/483/207/1/1444832071.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832071,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4518193604,47.0990976214,15.4518193604,47.0990976214",
+    "geom:latitude":47.099098,
+    "geom:longitude":15.451819,
+    "iso:country":"AT",
+    "lbl:latitude":47.099098,
+    "lbl:longitude":15.451819,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Mariagr\u00fcn"
+    ],
+    "name:eng_x_preferred":[
+        "Mariagruen"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"30c40656984f5f3dfcca1f9aac4a7318",
+    "wof:hierarchy":[],
+    "wof:id":1444832071,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Mariagruen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.451819360417852,
+    47.09909762139033,
+    15.451819360417852,
+    47.09909762139033
+],
+  "geometry": {"coordinates":[15.45181936041785,47.09909762139033],"type":"Point"}
+}

--- a/data/144/483/207/5/1444832075.geojson
+++ b/data/144/483/207/5/1444832075.geojson
@@ -32,15 +32,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"b9c2f00caf60942540460fea108c2f42",
-    "wof:hierarchy":[],
+    "wof:geomhash":"299c360b4f8dbf231248f791217ebad6",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444832075,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832075,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340979,
     "wof:name":"Sankt Gotthard",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -48,10 +65,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.414305714152695,
-    47.108929831591794,
-    15.414305714152695,
-    47.108929831591794
+    15.41430571415269,
+    47.10892983159179,
+    15.41430571415269,
+    47.10892983159179
 ],
   "geometry": {"coordinates":[15.41430571415269,47.10892983159179],"type":"Point"}
 }

--- a/data/144/483/207/5/1444832075.geojson
+++ b/data/144/483/207/5/1444832075.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444832075,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4143057142,47.1089298316,15.4143057142,47.1089298316",
+    "geom:latitude":47.10893,
+    "geom:longitude":15.414306,
+    "iso:country":"AT",
+    "lbl:latitude":47.10893,
+    "lbl:longitude":15.414306,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Sankt Gotthard"
+    ],
+    "name:deu_x_variant":[
+        "St. Gotthard"
+    ],
+    "name:eng_x_preferred":[
+        "Sankt Gotthard"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"b9c2f00caf60942540460fea108c2f42",
+    "wof:hierarchy":[],
+    "wof:id":1444832075,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Sankt Gotthard",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.414305714152695,
+    47.108929831591794,
+    15.414305714152695,
+    47.108929831591794
+],
+  "geometry": {"coordinates":[15.41430571415269,47.10892983159179],"type":"Point"}
+}

--- a/data/144/483/209/5/1444832095.geojson
+++ b/data/144/483/209/5/1444832095.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108839329,
+        85632785,
+        102049709,
+        85681687
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"41bc2f87be57cd2413b47d540767a8cf",
-    "wof:hierarchy":[],
+    "wof:geomhash":"000f935ef4729d2784f7d30774dd637c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":-1,
+            "neighbourhood_id":1444832095,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832095,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340979,
     "wof:name":"Raach",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.372552019746452,
+    15.37255201974645,
     47.1114976470962,
-    15.372552019746452,
+    15.37255201974645,
     47.1114976470962
 ],
   "geometry": {"coordinates":[15.37255201974645,47.1114976470962],"type":"Point"}

--- a/data/144/483/209/5/1444832095.geojson
+++ b/data/144/483/209/5/1444832095.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832095,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.3725520197,47.1114976471,15.3725520197,47.1114976471",
+    "geom:latitude":47.111498,
+    "geom:longitude":15.372552,
+    "iso:country":"AT",
+    "lbl:latitude":47.111498,
+    "lbl:longitude":15.372552,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Raach"
+    ],
+    "name:eng_x_preferred":[
+        "Raach"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"41bc2f87be57cd2413b47d540767a8cf",
+    "wof:hierarchy":[],
+    "wof:id":1444832095,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Raach",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.372552019746452,
+    47.1114976470962,
+    15.372552019746452,
+    47.1114976470962
+],
+  "geometry": {"coordinates":[15.37255201974645,47.1114976470962],"type":"Point"}
+}

--- a/data/144/483/210/3/1444832103.geojson
+++ b/data/144/483/210/3/1444832103.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832103,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4780501667,47.1177577066,15.4780501667,47.1177577066",
+    "geom:latitude":47.117758,
+    "geom:longitude":15.47805,
+    "iso:country":"AT",
+    "lbl:latitude":47.117758,
+    "lbl:longitude":15.47805,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Wenisbuch"
+    ],
+    "name:eng_x_preferred":[
+        "Wenisbuch"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"7d3b536e3829117bd2a783d055a9f2e1",
+    "wof:hierarchy":[],
+    "wof:id":1444832103,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Wenisbuch",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.478050166714372,
+    47.11775770661954,
+    15.478050166714372,
+    47.11775770661954
+],
+  "geometry": {"coordinates":[15.47805016671437,47.11775770661954],"type":"Point"}
+}

--- a/data/144/483/210/3/1444832103.geojson
+++ b/data/144/483/210/3/1444832103.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108839329,
+        85632785,
+        102049709,
+        85681687
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"7d3b536e3829117bd2a783d055a9f2e1",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f4f2069c63b4f5e99e1c6882b07789fc",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":-1,
+            "neighbourhood_id":1444832103,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832103,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340980,
     "wof:name":"Wenisbuch",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.478050166714372,
+    15.47805016671437,
     47.11775770661954,
-    15.478050166714372,
+    15.47805016671437,
     47.11775770661954
 ],
   "geometry": {"coordinates":[15.47805016671437,47.11775770661954],"type":"Point"}

--- a/data/144/483/211/1/1444832111.geojson
+++ b/data/144/483/211/1/1444832111.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832111,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.431122309,47.1017978495,15.431122309,47.1017978495",
+    "geom:latitude":47.101798,
+    "geom:longitude":15.431122,
+    "iso:country":"AT",
+    "lbl:latitude":47.101798,
+    "lbl:longitude":15.431122,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Unter Weizbach"
+    ],
+    "name:eng_x_preferred":[
+        "Unter Weizbach"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"5e67ce96a33efe70c01add4cd4b6acb8",
+    "wof:hierarchy":[],
+    "wof:id":1444832111,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Unter Weizbach",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.431122309007264,
+    47.10179784945691,
+    15.431122309007264,
+    47.10179784945691
+],
+  "geometry": {"coordinates":[15.43112230900726,47.10179784945691],"type":"Point"}
+}

--- a/data/144/483/211/1/1444832111.geojson
+++ b/data/144/483/211/1/1444832111.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"5e67ce96a33efe70c01add4cd4b6acb8",
-    "wof:hierarchy":[],
+    "wof:geomhash":"02caedbd55e9b097fee8513272bd28b7",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444832111,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832111,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340981,
     "wof:name":"Unter Weizbach",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.431122309007264,
+    15.43112230900726,
     47.10179784945691,
-    15.431122309007264,
+    15.43112230900726,
     47.10179784945691
 ],
   "geometry": {"coordinates":[15.43112230900726,47.10179784945691],"type":"Point"}

--- a/data/144/483/212/3/1444832123.geojson
+++ b/data/144/483/212/3/1444832123.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"4696372427d89c53f6a064931b7eaa29",
-    "wof:hierarchy":[],
+    "wof:geomhash":"abe9e8fc25effda76b4aee26afdfcded",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444832123,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832123,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340984,
     "wof:name":"Ober Weizbach",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.433353908030488,
+    15.43335390803049,
     47.11231327430986,
-    15.433353908030488,
+    15.43335390803049,
     47.11231327430986
 ],
   "geometry": {"coordinates":[15.43335390803049,47.11231327430986],"type":"Point"}

--- a/data/144/483/212/3/1444832123.geojson
+++ b/data/144/483/212/3/1444832123.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832123,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.433353908,47.1123132743,15.433353908,47.1123132743",
+    "geom:latitude":47.112313,
+    "geom:longitude":15.433354,
+    "iso:country":"AT",
+    "lbl:latitude":47.112313,
+    "lbl:longitude":15.433354,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Ober Weizbach"
+    ],
+    "name:eng_x_preferred":[
+        "Ober Weizbach"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"4696372427d89c53f6a064931b7eaa29",
+    "wof:hierarchy":[],
+    "wof:id":1444832123,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Ober Weizbach",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.433353908030488,
+    47.11231327430986,
+    15.433353908030488,
+    47.11231327430986
+],
+  "geometry": {"coordinates":[15.43335390803049,47.11231327430986],"type":"Point"}
+}

--- a/data/144/483/213/3/1444832133.geojson
+++ b/data/144/483/213/3/1444832133.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832133,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4334397388,47.1224470094,15.4334397388,47.1224470094",
+    "geom:latitude":47.122447,
+    "geom:longitude":15.43344,
+    "iso:country":"AT",
+    "lbl:latitude":47.122447,
+    "lbl:longitude":15.43344,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Ro\u00dfegg"
+    ],
+    "name:eng_x_preferred":[
+        "Rossegg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"0bd69a64d4788da9cce5f8ba585ad776",
+    "wof:hierarchy":[],
+    "wof:id":1444832133,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Rossegg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.433439738762148,
+    47.12244700936579,
+    15.433439738762148,
+    47.12244700936579
+],
+  "geometry": {"coordinates":[15.43343973876215,47.12244700936579],"type":"Point"}
+}

--- a/data/144/483/213/3/1444832133.geojson
+++ b/data/144/483/213/3/1444832133.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"0bd69a64d4788da9cce5f8ba585ad776",
-    "wof:hierarchy":[],
+    "wof:geomhash":"3190e7924a802f6444ca39e2e7377b22",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444832133,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832133,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340984,
     "wof:name":"Rossegg",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.433439738762148,
+    15.43343973876215,
     47.12244700936579,
-    15.433439738762148,
+    15.43343973876215,
     47.12244700936579
 ],
   "geometry": {"coordinates":[15.43343973876215,47.12244700936579],"type":"Point"}

--- a/data/144/483/214/3/1444832143.geojson
+++ b/data/144/483/214/3/1444832143.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"ec70c724b3875ce56abf8ba126fef9e9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a0c57b298c84586f2a506543f588fe88",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444832143,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832143,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340985,
     "wof:name":"Unteradritz",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.422596456328787,
-    47.108798627319786,
-    15.422596456328787,
-    47.108798627319786
+    15.42259645632879,
+    47.10879862731979,
+    15.42259645632879,
+    47.10879862731979
 ],
   "geometry": {"coordinates":[15.42259645632879,47.10879862731979],"type":"Point"}
 }

--- a/data/144/483/214/3/1444832143.geojson
+++ b/data/144/483/214/3/1444832143.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832143,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4225964563,47.1087986273,15.4225964563,47.1087986273",
+    "geom:latitude":47.108799,
+    "geom:longitude":15.422596,
+    "iso:country":"AT",
+    "lbl:latitude":47.108799,
+    "lbl:longitude":15.422596,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Unteradritz"
+    ],
+    "name:eng_x_preferred":[
+        "Unteradritz"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"ec70c724b3875ce56abf8ba126fef9e9",
+    "wof:hierarchy":[],
+    "wof:id":1444832143,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Unteradritz",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.422596456328787,
+    47.108798627319786,
+    15.422596456328787,
+    47.108798627319786
+],
+  "geometry": {"coordinates":[15.42259645632879,47.10879862731979],"type":"Point"}
+}

--- a/data/144/483/215/5/1444832155.geojson
+++ b/data/144/483/215/5/1444832155.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832155,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4201359754,47.1136664976,15.4201359754,47.1136664976",
+    "geom:latitude":47.113666,
+    "geom:longitude":15.420136,
+    "iso:country":"AT",
+    "lbl:latitude":47.113666,
+    "lbl:longitude":15.420136,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Oberandritz"
+    ],
+    "name:eng_x_preferred":[
+        "Oberandritz"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"9cfed8101180f72e37186121e6310d63",
+    "wof:hierarchy":[],
+    "wof:id":1444832155,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Oberandritz",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.420135975354466,
+    47.113666497551286,
+    15.420135975354466,
+    47.113666497551286
+],
+  "geometry": {"coordinates":[15.42013597535447,47.11366649755129],"type":"Point"}
+}

--- a/data/144/483/215/5/1444832155.geojson
+++ b/data/144/483/215/5/1444832155.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"9cfed8101180f72e37186121e6310d63",
-    "wof:hierarchy":[],
+    "wof:geomhash":"bfee9b8aaf1d0e9b95421a96a260364e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444832155,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832155,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340986,
     "wof:name":"Oberandritz",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.420135975354466,
-    47.113666497551286,
-    15.420135975354466,
-    47.113666497551286
+    15.42013597535447,
+    47.11366649755129,
+    15.42013597535447,
+    47.11366649755129
 ],
   "geometry": {"coordinates":[15.42013597535447,47.11366649755129],"type":"Point"}
 }

--- a/data/144/483/216/5/1444832165.geojson
+++ b/data/144/483/216/5/1444832165.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832165,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.4121537173,47.1281506453,15.4121537173,47.1281506453",
+    "geom:latitude":47.128151,
+    "geom:longitude":15.412154,
+    "iso:country":"AT",
+    "lbl:latitude":47.128151,
+    "lbl:longitude":15.412154,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Rohrerberg"
+    ],
+    "name:eng_x_preferred":[
+        "Rohrerberg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"b2ec718cce484e09b0370a3b2a635d36",
+    "wof:hierarchy":[],
+    "wof:id":1444832165,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Rohrerberg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.412153717309852,
+    47.12815064525528,
+    15.412153717309852,
+    47.12815064525528
+],
+  "geometry": {"coordinates":[15.41215371730985,47.12815064525528],"type":"Point"}
+}

--- a/data/144/483/216/5/1444832165.geojson
+++ b/data/144/483/216/5/1444832165.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681687,
+        102191581,
+        1108839329,
+        85632785,
+        101748063,
+        102049709
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"b2ec718cce484e09b0370a3b2a635d36",
-    "wof:hierarchy":[],
+    "wof:geomhash":"5ad4e58060cb7d2cf9589e6eee8f954a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":101748063,
+            "neighbourhood_id":1444832165,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832165,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340989,
     "wof:name":"Rohrerberg",
-    "wof:parent_id":-1,
+    "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.412153717309852,
+    15.41215371730985,
     47.12815064525528,
-    15.412153717309852,
+    15.41215371730985,
     47.12815064525528
 ],
   "geometry": {"coordinates":[15.41215371730985,47.12815064525528],"type":"Point"}

--- a/data/144/483/216/9/1444832169.geojson
+++ b/data/144/483/216/9/1444832169.geojson
@@ -32,13 +32,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108839329,
+        85632785,
+        102049709,
+        85681687
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"ae2a395bf6f876f01fa911efc0228283",
-    "wof:hierarchy":[],
+    "wof:geomhash":"62d68f1dff239a4882e32a4db3467ec9",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049709,
+            "localadmin_id":1108839329,
+            "locality_id":-1,
+            "neighbourhood_id":1444832169,
+            "region_id":85681687
+        }
+    ],
     "wof:id":1444832169,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340989,
     "wof:name":"Weinzoedl",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -48,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    15.391668782686413,
-    47.109382795256046,
-    15.391668782686413,
-    47.109382795256046
+    15.39166878268641,
+    47.10938279525605,
+    15.39166878268641,
+    47.10938279525605
 ],
   "geometry": {"coordinates":[15.39166878268641,47.10938279525605],"type":"Point"}
 }

--- a/data/144/483/216/9/1444832169.geojson
+++ b/data/144/483/216/9/1444832169.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444832169,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"15.3916687827,47.1093827953,15.3916687827,47.1093827953",
+    "geom:latitude":47.109383,
+    "geom:longitude":15.391669,
+    "iso:country":"AT",
+    "lbl:latitude":47.109383,
+    "lbl:longitude":15.391669,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Weinz\u00f6dl"
+    ],
+    "name:deu_x_variant":[
+        "Weinz\u00f6ttl"
+    ],
+    "name:eng_x_preferred":[
+        "Weinzoedl"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"ae2a395bf6f876f01fa911efc0228283",
+    "wof:hierarchy":[],
+    "wof:id":1444832169,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Weinzoedl",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    15.391668782686413,
+    47.109382795256046,
+    15.391668782686413,
+    47.109382795256046
+],
+  "geometry": {"coordinates":[15.39166878268641,47.10938279525605],"type":"Point"}
+}

--- a/data/144/483/217/7/1444832177.geojson
+++ b/data/144/483/217/7/1444832177.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"ac41ac66b91dc1726e8dfbfec1eefa13",
-    "wof:hierarchy":[],
+    "wof:geomhash":"feca425614c357c5fabee420817fc143",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832177,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832177,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340990,
     "wof:name":"Leopoldskroner-Moos",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.020108446364498,
+    13.0201084463645,
     47.77116700322717,
-    13.020108446364498,
+    13.0201084463645,
     47.77116700322717
 ],
   "geometry": {"coordinates":[13.0201084463645,47.77116700322717],"type":"Point"}

--- a/data/144/483/217/7/1444832177.geojson
+++ b/data/144/483/217/7/1444832177.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832177,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0201084464,47.7711670032,13.0201084464,47.7711670032",
+    "geom:latitude":47.771167,
+    "geom:longitude":13.020108,
+    "iso:country":"AT",
+    "lbl:latitude":47.771167,
+    "lbl:longitude":13.020108,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Leopoldskroner-Moos"
+    ],
+    "name:eng_x_preferred":[
+        "Leopoldskroner-Moos"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"ac41ac66b91dc1726e8dfbfec1eefa13",
+    "wof:hierarchy":[],
+    "wof:id":1444832177,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Leopoldskroner-Moos",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.020108446364498,
+    47.77116700322717,
+    13.020108446364498,
+    47.77116700322717
+],
+  "geometry": {"coordinates":[13.0201084463645,47.77116700322717],"type":"Point"}
+}

--- a/data/144/483/219/3/1444832193.geojson
+++ b/data/144/483/219/3/1444832193.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"ad3c347be56cfc5211b0db01a975af5b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"27afd4529bc64e834f679dc7a54df7c3",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832193,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832193,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340991,
     "wof:name":"Maxglan",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.017705185877947,
+    13.01770518587795,
     47.80261573504584,
-    13.017705185877947,
+    13.01770518587795,
     47.80261573504584
 ],
   "geometry": {"coordinates":[13.01770518587795,47.80261573504584],"type":"Point"}

--- a/data/144/483/219/3/1444832193.geojson
+++ b/data/144/483/219/3/1444832193.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832193,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0177051859,47.802615735,13.0177051859,47.802615735",
+    "geom:latitude":47.802616,
+    "geom:longitude":13.017705,
+    "iso:country":"AT",
+    "lbl:latitude":47.802616,
+    "lbl:longitude":13.017705,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Maxglan"
+    ],
+    "name:eng_x_preferred":[
+        "Maxglan"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"ad3c347be56cfc5211b0db01a975af5b",
+    "wof:hierarchy":[],
+    "wof:id":1444832193,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Maxglan",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.017705185877947,
+    47.80261573504584,
+    13.017705185877947,
+    47.80261573504584
+],
+  "geometry": {"coordinates":[13.01770518587795,47.80261573504584],"type":"Point"}
+}

--- a/data/144/483/220/1/1444832201.geojson
+++ b/data/144/483/220/1/1444832201.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"5cfaab012b736be29a415252c7000588",
-    "wof:hierarchy":[],
+    "wof:geomhash":"fc796f6d7f31f6f63076d01334eb235d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444832201,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832201,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340994,
     "wof:name":"Maxglan West",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    12.998593542961105,
+    12.99859354296111,
     47.78785488274194,
-    12.998593542961105,
+    12.99859354296111,
     47.78785488274194
 ],
   "geometry": {"coordinates":[12.99859354296111,47.78785488274194],"type":"Point"}

--- a/data/144/483/220/1/1444832201.geojson
+++ b/data/144/483/220/1/1444832201.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832201,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"12.998593543,47.7878548827,12.998593543,47.7878548827",
+    "geom:latitude":47.787855,
+    "geom:longitude":12.998594,
+    "iso:country":"AT",
+    "lbl:latitude":47.787855,
+    "lbl:longitude":12.998594,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Maxglan West"
+    ],
+    "name:eng_x_preferred":[
+        "Maxglan West"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"5cfaab012b736be29a415252c7000588",
+    "wof:hierarchy":[],
+    "wof:id":1444832201,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Maxglan West",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    12.998593542961105,
+    47.78785488274194,
+    12.998593542961105,
+    47.78785488274194
+],
+  "geometry": {"coordinates":[12.99859354296111,47.78785488274194],"type":"Point"}
+}

--- a/data/144/483/220/9/1444832209.geojson
+++ b/data/144/483/220/9/1444832209.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832209,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0372745927,47.7630902998,13.0372745927,47.7630902998",
+    "geom:latitude":47.76309,
+    "geom:longitude":13.037275,
+    "iso:country":"AT",
+    "lbl:latitude":47.76309,
+    "lbl:longitude":13.037275,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Gneis-S\u00fcd"
+    ],
+    "name:eng_x_preferred":[
+        "Gneis-Sued"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"6b90cca8591ea4fdfc0a07c6e8624df4",
+    "wof:hierarchy":[],
+    "wof:id":1444832209,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Gneis-Sued",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.037274592696992,
+    47.763090299785404,
+    13.037274592696992,
+    47.763090299785404
+],
+  "geometry": {"coordinates":[13.03727459269699,47.7630902997854],"type":"Point"}
+}

--- a/data/144/483/220/9/1444832209.geojson
+++ b/data/144/483/220/9/1444832209.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"6b90cca8591ea4fdfc0a07c6e8624df4",
-    "wof:hierarchy":[],
+    "wof:geomhash":"cd883f5dbf83d0d8f7e6741ff0aa7ec9",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444832209,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832209,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340995,
     "wof:name":"Gneis-Sued",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,10 +61,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.037274592696992,
-    47.763090299785404,
-    13.037274592696992,
-    47.763090299785404
+    13.03727459269699,
+    47.7630902997854,
+    13.03727459269699,
+    47.7630902997854
 ],
   "geometry": {"coordinates":[13.03727459269699,47.7630902997854],"type":"Point"}
 }

--- a/data/144/483/221/9/1444832219.geojson
+++ b/data/144/483/221/9/1444832219.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832219,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0413944678,47.7782811554,13.0413944678,47.7782811554",
+    "geom:latitude":47.778281,
+    "geom:longitude":13.041394,
+    "iso:country":"AT",
+    "lbl:latitude":47.778281,
+    "lbl:longitude":13.041394,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Gneis"
+    ],
+    "name:eng_x_preferred":[
+        "Gneis"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"276257482a0d3644dcefa2b1ba85fc74",
+    "wof:hierarchy":[],
+    "wof:id":1444832219,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Gneis",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.04139446781679,
+    47.778281155351905,
+    13.04139446781679,
+    47.778281155351905
+],
+  "geometry": {"coordinates":[13.04139446781679,47.77828115535191],"type":"Point"}
+}

--- a/data/144/483/221/9/1444832219.geojson
+++ b/data/144/483/221/9/1444832219.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"276257482a0d3644dcefa2b1ba85fc74",
-    "wof:hierarchy":[],
+    "wof:geomhash":"31b35b8d516ea7ce7418021826a1cc66",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832219,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832219,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340995,
     "wof:name":"Gneis",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -46,9 +63,9 @@
 },
   "bbox": [
     13.04139446781679,
-    47.778281155351905,
+    47.77828115535191,
     13.04139446781679,
-    47.778281155351905
+    47.77828115535191
 ],
   "geometry": {"coordinates":[13.04139446781679,47.77828115535191],"type":"Point"}
 }

--- a/data/144/483/222/7/1444832227.geojson
+++ b/data/144/483/222/7/1444832227.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832227,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.031323662,47.7950436246,13.031323662,47.7950436246",
+    "geom:latitude":47.795044,
+    "geom:longitude":13.031324,
+    "iso:country":"AT",
+    "lbl:latitude":47.795044,
+    "lbl:longitude":13.031324,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Riedenburg"
+    ],
+    "name:eng_x_preferred":[
+        "Riedenburg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"c1337e50a021ed1ad299350fe9ece034",
+    "wof:hierarchy":[],
+    "wof:id":1444832227,
+    "wof:lastmodified":1566333180,
+    "wof:name":"Riedenburg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.031323661968397,
+    47.7950436246384,
+    13.031323661968397,
+    47.7950436246384
+],
+  "geometry": {"coordinates":[13.0313236619684,47.7950436246384],"type":"Point"}
+}

--- a/data/144/483/222/7/1444832227.geojson
+++ b/data/144/483/222/7/1444832227.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"c1337e50a021ed1ad299350fe9ece034",
-    "wof:hierarchy":[],
+    "wof:geomhash":"aeefdc3279ca23a5e98613605e7fc582",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832227,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832227,
-    "wof:lastmodified":1566333180,
+    "wof:lastmodified":1566340996,
     "wof:name":"Riedenburg",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.031323661968397,
+    13.0313236619684,
     47.7950436246384,
-    13.031323661968397,
+    13.0313236619684,
     47.7950436246384
 ],
   "geometry": {"coordinates":[13.0313236619684,47.7950436246384],"type":"Point"}

--- a/data/144/483/223/1/1444832231.geojson
+++ b/data/144/483/223/1/1444832231.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"311b4b6523a4defea4d6149b9ed0a6ef",
-    "wof:hierarchy":[],
+    "wof:geomhash":"bff917939eb5525ff472170fd4b10fd0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832231,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832231,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566340999,
     "wof:name":"Altstadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.046887634643191,
+    13.04688763464319,
     47.8001558793216,
-    13.046887634643191,
+    13.04688763464319,
     47.8001558793216
 ],
   "geometry": {"coordinates":[13.04688763464319,47.8001558793216],"type":"Point"}

--- a/data/144/483/223/1/1444832231.geojson
+++ b/data/144/483/223/1/1444832231.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832231,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0468876346,47.8001558793,13.0468876346,47.8001558793",
+    "geom:latitude":47.800156,
+    "geom:longitude":13.046888,
+    "iso:country":"AT",
+    "lbl:latitude":47.800156,
+    "lbl:longitude":13.046888,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Altstadt"
+    ],
+    "name:eng_x_preferred":[
+        "Altstadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"311b4b6523a4defea4d6149b9ed0a6ef",
+    "wof:hierarchy":[],
+    "wof:id":1444832231,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Altstadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.046887634643191,
+    47.8001558793216,
+    13.046887634643191,
+    47.8001558793216
+],
+  "geometry": {"coordinates":[13.04688763464319,47.8001558793216],"type":"Point"}
+}

--- a/data/144/483/224/3/1444832243.geojson
+++ b/data/144/483/224/3/1444832243.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832243,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0527241244,47.7933138051,13.0527241244,47.7933138051",
+    "geom:latitude":47.793314,
+    "geom:longitude":13.052724,
+    "iso:country":"AT",
+    "lbl:latitude":47.793314,
+    "lbl:longitude":13.052724,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Nonntal"
+    ],
+    "name:eng_x_preferred":[
+        "Nonntal"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"63654bd086a6c97b9d75c1cd0eb3f2c9",
+    "wof:hierarchy":[],
+    "wof:id":1444832243,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Nonntal",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.05272412439624,
+    47.79331380509397,
+    13.05272412439624,
+    47.79331380509397
+],
+  "geometry": {"coordinates":[13.05272412439624,47.79331380509397],"type":"Point"}
+}

--- a/data/144/483/224/3/1444832243.geojson
+++ b/data/144/483/224/3/1444832243.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"63654bd086a6c97b9d75c1cd0eb3f2c9",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832243,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832243,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341000,
     "wof:name":"Nonntal",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/483/225/1/1444832251.geojson
+++ b/data/144/483/225/1/1444832251.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"814d50bc81ea1ff4fc9f26865a3ce772",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832251,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832251,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341000,
     "wof:name":"Morzg",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/483/225/1/1444832251.geojson
+++ b/data/144/483/225/1/1444832251.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832251,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0550701644,47.771397725,13.0550701644,47.771397725",
+    "geom:latitude":47.771398,
+    "geom:longitude":13.05507,
+    "iso:country":"AT",
+    "lbl:latitude":47.771398,
+    "lbl:longitude":13.05507,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Morzg"
+    ],
+    "name:eng_x_preferred":[
+        "Morzg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"814d50bc81ea1ff4fc9f26865a3ce772",
+    "wof:hierarchy":[],
+    "wof:id":1444832251,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Morzg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.05507016439501,
+    47.77139772497484,
+    13.05507016439501,
+    47.77139772497484
+],
+  "geometry": {"coordinates":[13.05507016439501,47.77139772497484],"type":"Point"}
+}

--- a/data/144/483/226/1/1444832261.geojson
+++ b/data/144/483/226/1/1444832261.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"a6cec24257756f257a9623ef5043ac79",
-    "wof:hierarchy":[],
+    "wof:geomhash":"5d2dc0c6af2eb76c4a6355cf1bb495da",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832261,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832261,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341001,
     "wof:name":"Salzburg-Sued",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.068631419997685,
-    47.781780191520106,
-    13.068631419997685,
-    47.781780191520106
+    13.06863141999768,
+    47.78178019152011,
+    13.06863141999768,
+    47.78178019152011
 ],
   "geometry": {"coordinates":[13.06863141999768,47.78178019152011],"type":"Point"}
 }

--- a/data/144/483/226/1/1444832261.geojson
+++ b/data/144/483/226/1/1444832261.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832261,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.06863142,47.7817801915,13.06863142,47.7817801915",
+    "geom:latitude":47.78178,
+    "geom:longitude":13.068631,
+    "iso:country":"AT",
+    "lbl:latitude":47.78178,
+    "lbl:longitude":13.068631,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Salzburg-S\u00fcd"
+    ],
+    "name:eng_x_preferred":[
+        "Salzburg-Sued"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"a6cec24257756f257a9623ef5043ac79",
+    "wof:hierarchy":[],
+    "wof:id":1444832261,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Salzburg-Sued",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.068631419997685,
+    47.781780191520106,
+    13.068631419997685,
+    47.781780191520106
+],
+  "geometry": {"coordinates":[13.06863141999768,47.78178019152011],"type":"Point"}
+}

--- a/data/144/483/227/7/1444832277.geojson
+++ b/data/144/483/227/7/1444832277.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"a9e4a8cec4f4c9b2f38ccf6669f36e6a",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ab8ec9a267897fcc67d40168f17b655a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832277,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832277,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341004,
     "wof:name":"Aigen",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.078988328284959,
+    13.07898832828496,
     47.78935422458799,
-    13.078988328284959,
+    13.07898832828496,
     47.78935422458799
 ],
   "geometry": {"coordinates":[13.07898832828496,47.78935422458799],"type":"Point"}

--- a/data/144/483/227/7/1444832277.geojson
+++ b/data/144/483/227/7/1444832277.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832277,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0789883283,47.7893542246,13.0789883283,47.7893542246",
+    "geom:latitude":47.789354,
+    "geom:longitude":13.078988,
+    "iso:country":"AT",
+    "lbl:latitude":47.789354,
+    "lbl:longitude":13.078988,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Aigen"
+    ],
+    "name:eng_x_preferred":[
+        "Aigen"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"a9e4a8cec4f4c9b2f38ccf6669f36e6a",
+    "wof:hierarchy":[],
+    "wof:id":1444832277,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Aigen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.078988328284959,
+    47.78935422458799,
+    13.078988328284959,
+    47.78935422458799
+],
+  "geometry": {"coordinates":[13.07898832828496,47.78935422458799],"type":"Point"}
+}

--- a/data/144/483/228/3/1444832283.geojson
+++ b/data/144/483/228/3/1444832283.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832283,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0439121693,47.8070739103,13.0439121693,47.8070739103",
+    "geom:latitude":47.807074,
+    "geom:longitude":13.043912,
+    "iso:country":"AT",
+    "lbl:latitude":47.807074,
+    "lbl:longitude":13.043912,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Neustadt"
+    ],
+    "name:eng_x_preferred":[
+        "Neustadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"870939bbaa9809bf2584002a4781e262",
+    "wof:hierarchy":[],
+    "wof:id":1444832283,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Neustadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.043912169278892,
+    47.807073910257834,
+    13.043912169278892,
+    47.807073910257834
+],
+  "geometry": {"coordinates":[13.04391216927889,47.80707391025783],"type":"Point"}
+}

--- a/data/144/483/228/3/1444832283.geojson
+++ b/data/144/483/228/3/1444832283.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"870939bbaa9809bf2584002a4781e262",
-    "wof:hierarchy":[],
+    "wof:geomhash":"5099c829e1f7ac7847b3e8d00d34ea00",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832283,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832283,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341005,
     "wof:name":"Neustadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.043912169278892,
-    47.807073910257834,
-    13.043912169278892,
-    47.807073910257834
+    13.04391216927889,
+    47.80707391025783,
+    13.04391216927889,
+    47.80707391025783
 ],
   "geometry": {"coordinates":[13.04391216927889,47.80707391025783],"type":"Point"}
 }

--- a/data/144/483/229/9/1444832299.geojson
+++ b/data/144/483/229/9/1444832299.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"1fb2d52659d66855ea59256b51529ee0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f56a195bb98f95266ba6b238fda10c52",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832299,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832299,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341005,
     "wof:name":"Muelln",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.031209220992846,
+    13.03120922099285,
     47.80538292125892,
-    13.031209220992846,
+    13.03120922099285,
     47.80538292125892
 ],
   "geometry": {"coordinates":[13.03120922099285,47.80538292125892],"type":"Point"}

--- a/data/144/483/229/9/1444832299.geojson
+++ b/data/144/483/229/9/1444832299.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832299,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.031209221,47.8053829213,13.031209221,47.8053829213",
+    "geom:latitude":47.805383,
+    "geom:longitude":13.031209,
+    "iso:country":"AT",
+    "lbl:latitude":47.805383,
+    "lbl:longitude":13.031209,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "M\u00fclln"
+    ],
+    "name:eng_x_preferred":[
+        "Muelln"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"1fb2d52659d66855ea59256b51529ee0",
+    "wof:hierarchy":[],
+    "wof:id":1444832299,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Muelln",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.031209220992846,
+    47.80538292125892,
+    13.031209220992846,
+    47.80538292125892
+],
+  "geometry": {"coordinates":[13.03120922099285,47.80538292125892],"type":"Point"}
+}

--- a/data/144/483/231/3/1444832313.geojson
+++ b/data/144/483/231/3/1444832313.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832313,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0560429127,47.8131456448,13.0560429127,47.8131456448",
+    "geom:latitude":47.813146,
+    "geom:longitude":13.056043,
+    "iso:country":"AT",
+    "lbl:latitude":47.813146,
+    "lbl:longitude":13.056043,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Schallmoos"
+    ],
+    "name:eng_x_preferred":[
+        "Schallmoos"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"aa911a44dc43480899d8a2773c10435c",
+    "wof:hierarchy":[],
+    "wof:id":1444832313,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Schallmoos",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.056042912687186,
+    47.813145644791724,
+    13.056042912687186,
+    47.813145644791724
+],
+  "geometry": {"coordinates":[13.05604291268719,47.81314564479172],"type":"Point"}
+}

--- a/data/144/483/231/3/1444832313.geojson
+++ b/data/144/483/231/3/1444832313.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"aa911a44dc43480899d8a2773c10435c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"fee61f882322e20d37544ccc478f894e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832313,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832313,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341006,
     "wof:name":"Schallmoos",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.056042912687186,
-    47.813145644791724,
-    13.056042912687186,
-    47.813145644791724
+    13.05604291268719,
+    47.81314564479172,
+    13.05604291268719,
+    47.81314564479172
 ],
   "geometry": {"coordinates":[13.05604291268719,47.81314564479172],"type":"Point"}
 }

--- a/data/144/483/231/9/1444832319.geojson
+++ b/data/144/483/231/9/1444832319.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832319,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.1001026883,47.7938519823,13.1001026883,47.7938519823",
+    "geom:latitude":47.793852,
+    "geom:longitude":13.100103,
+    "iso:country":"AT",
+    "lbl:latitude":47.793852,
+    "lbl:longitude":13.100103,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Gaisberg"
+    ],
+    "name:eng_x_preferred":[
+        "Gaisberg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"221ba741dd4592488b7b5e1724ecf38e",
+    "wof:hierarchy":[],
+    "wof:id":1444832319,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Gaisberg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.100102688273923,
+    47.79385198233895,
+    13.100102688273923,
+    47.79385198233895
+],
+  "geometry": {"coordinates":[13.10010268827392,47.79385198233895],"type":"Point"}
+}

--- a/data/144/483/231/9/1444832319.geojson
+++ b/data/144/483/231/9/1444832319.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"221ba741dd4592488b7b5e1724ecf38e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"cd0e14332846c66d3850654278079417",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444832319,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832319,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341009,
     "wof:name":"Gaisberg",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.100102688273923,
+    13.10010268827392,
     47.79385198233895,
-    13.100102688273923,
+    13.10010268827392,
     47.79385198233895
 ],
   "geometry": {"coordinates":[13.10010268827392,47.79385198233895],"type":"Point"}

--- a/data/144/483/232/9/1444832329.geojson
+++ b/data/144/483/232/9/1444832329.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832329,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0712635624,47.8019239082,13.0712635624,47.8019239082",
+    "geom:latitude":47.801924,
+    "geom:longitude":13.071264,
+    "iso:country":"AT",
+    "lbl:latitude":47.801924,
+    "lbl:longitude":13.071264,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Parsch"
+    ],
+    "name:eng_x_preferred":[
+        "Parsch"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"8732907f747b0ce5283ef5b06045d605",
+    "wof:hierarchy":[],
+    "wof:id":1444832329,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Parsch",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.071263562435334,
+    47.801923908200564,
+    13.071263562435334,
+    47.801923908200564
+],
+  "geometry": {"coordinates":[13.07126356243533,47.80192390820056],"type":"Point"}
+}

--- a/data/144/483/232/9/1444832329.geojson
+++ b/data/144/483/232/9/1444832329.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"8732907f747b0ce5283ef5b06045d605",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c7f6e53ade67acda3c4eb1354d1d34b0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832329,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832329,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341010,
     "wof:name":"Parsch",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.071263562435334,
-    47.801923908200564,
-    13.071263562435334,
-    47.801923908200564
+    13.07126356243533,
+    47.80192390820056,
+    13.07126356243533,
+    47.80192390820056
 ],
   "geometry": {"coordinates":[13.07126356243533,47.80192390820056],"type":"Point"}
 }

--- a/data/144/483/233/9/1444832339.geojson
+++ b/data/144/483/233/9/1444832339.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832339,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0736382127,47.8237118409,13.0736382127,47.8237118409",
+    "geom:latitude":47.823712,
+    "geom:longitude":13.073638,
+    "iso:country":"AT",
+    "lbl:latitude":47.823712,
+    "lbl:longitude":13.073638,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Langwied"
+    ],
+    "name:eng_x_preferred":[
+        "Langwied"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"ee56c42eae873ce26f546a701204b6af",
+    "wof:hierarchy":[],
+    "wof:id":1444832339,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Langwied",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.073638212677993,
+    47.82371184091709,
+    13.073638212677993,
+    47.82371184091709
+],
+  "geometry": {"coordinates":[13.07363821267799,47.82371184091709],"type":"Point"}
+}

--- a/data/144/483/233/9/1444832339.geojson
+++ b/data/144/483/233/9/1444832339.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"ee56c42eae873ce26f546a701204b6af",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a8eb42cc7c1774ae5d43b96fc2a362c9",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832339,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832339,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341010,
     "wof:name":"Langwied",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.073638212677993,
+    13.07363821267799,
     47.82371184091709,
-    13.073638212677993,
+    13.07363821267799,
     47.82371184091709
 ],
   "geometry": {"coordinates":[13.07363821267799,47.82371184091709],"type":"Point"}

--- a/data/144/483/235/1/1444832351.geojson
+++ b/data/144/483/235/1/1444832351.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"ab1f165c8da4dc5dd0fc7d97c399d635",
-    "wof:hierarchy":[],
+    "wof:geomhash":"4685caba2fac9347996bc001cb044c1d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832351,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832351,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341012,
     "wof:name":"Itzling",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.042538877572293,
+    13.04253887757229,
     47.82328923754545,
-    13.042538877572293,
+    13.04253887757229,
     47.82328923754545
 ],
   "geometry": {"coordinates":[13.04253887757229,47.82328923754545],"type":"Point"}

--- a/data/144/483/235/1/1444832351.geojson
+++ b/data/144/483/235/1/1444832351.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832351,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0425388776,47.8232892375,13.0425388776,47.8232892375",
+    "geom:latitude":47.823289,
+    "geom:longitude":13.042539,
+    "iso:country":"AT",
+    "lbl:latitude":47.823289,
+    "lbl:longitude":13.042539,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Itzling"
+    ],
+    "name:eng_x_preferred":[
+        "Itzling"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"ab1f165c8da4dc5dd0fc7d97c399d635",
+    "wof:hierarchy":[],
+    "wof:id":1444832351,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Itzling",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.042538877572293,
+    47.82328923754545,
+    13.042538877572293,
+    47.82328923754545
+],
+  "geometry": {"coordinates":[13.04253887757229,47.82328923754545],"type":"Point"}
+}

--- a/data/144/483/236/3/1444832363.geojson
+++ b/data/144/483/236/3/1444832363.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"85c9ceb948863d9d2f8abfaaafa3ad49",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7eeaf496408fccf9e815c1d282e60a4f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832363,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832363,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341013,
     "wof:name":"Elisabeth-Vorstadt",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.041051144890142,
-    47.814375276735454,
-    13.041051144890142,
-    47.814375276735454
+    13.04105114489014,
+    47.81437527673545,
+    13.04105114489014,
+    47.81437527673545
 ],
   "geometry": {"coordinates":[13.04105114489014,47.81437527673545],"type":"Point"}
 }

--- a/data/144/483/236/3/1444832363.geojson
+++ b/data/144/483/236/3/1444832363.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832363,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0410511449,47.8143752767,13.0410511449,47.8143752767",
+    "geom:latitude":47.814375,
+    "geom:longitude":13.041051,
+    "iso:country":"AT",
+    "lbl:latitude":47.814375,
+    "lbl:longitude":13.041051,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Elisabeth-Vorstadt"
+    ],
+    "name:eng_x_preferred":[
+        "Elisabeth-Vorstadt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"85c9ceb948863d9d2f8abfaaafa3ad49",
+    "wof:hierarchy":[],
+    "wof:id":1444832363,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Elisabeth-Vorstadt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.041051144890142,
+    47.814375276735454,
+    13.041051144890142,
+    47.814375276735454
+],
+  "geometry": {"coordinates":[13.04105114489014,47.81437527673545],"type":"Point"}
+}

--- a/data/144/483/237/3/1444832373.geojson
+++ b/data/144/483/237/3/1444832373.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832373,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0301792522,47.8136067602,13.0301792522,47.8136067602",
+    "geom:latitude":47.813607,
+    "geom:longitude":13.030179,
+    "iso:country":"AT",
+    "lbl:latitude":47.813607,
+    "lbl:longitude":13.030179,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Lehen"
+    ],
+    "name:eng_x_preferred":[
+        "Lehen"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"cbc5ec0fc50ddfd9673245e6c539a3e0",
+    "wof:hierarchy":[],
+    "wof:id":1444832373,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Lehen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.030179252212896,
+    47.81360676018281,
+    13.030179252212896,
+    47.81360676018281
+],
+  "geometry": {"coordinates":[13.0301792522129,47.81360676018281],"type":"Point"}
+}

--- a/data/144/483/237/3/1444832373.geojson
+++ b/data/144/483/237/3/1444832373.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"cbc5ec0fc50ddfd9673245e6c539a3e0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8fc45ef1a5218c4ca4d234fdf8abdb1c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832373,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832373,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341016,
     "wof:name":"Lehen",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.030179252212896,
+    13.0301792522129,
     47.81360676018281,
-    13.030179252212896,
+    13.0301792522129,
     47.81360676018281
 ],
   "geometry": {"coordinates":[13.0301792522129,47.81360676018281],"type":"Point"}

--- a/data/144/483/238/5/1444832385.geojson
+++ b/data/144/483/238/5/1444832385.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"904f246637de1ff3aa95239ce04e4f44",
-    "wof:hierarchy":[],
+    "wof:geomhash":"4bab453db25cbf96a916e8421fc0e19b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832385,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832385,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341017,
     "wof:name":"Liefering",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.017419083439073,
-    47.820484578883416,
-    13.017419083439073,
-    47.820484578883416
+    13.01741908343907,
+    47.82048457888342,
+    13.01741908343907,
+    47.82048457888342
 ],
   "geometry": {"coordinates":[13.01741908343907,47.82048457888342],"type":"Point"}
 }

--- a/data/144/483/238/5/1444832385.geojson
+++ b/data/144/483/238/5/1444832385.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832385,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0174190834,47.8204845789,13.0174190834,47.8204845789",
+    "geom:latitude":47.820485,
+    "geom:longitude":13.017419,
+    "iso:country":"AT",
+    "lbl:latitude":47.820484,
+    "lbl:longitude":13.017419,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Liefering"
+    ],
+    "name:eng_x_preferred":[
+        "Liefering"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"904f246637de1ff3aa95239ce04e4f44",
+    "wof:hierarchy":[],
+    "wof:id":1444832385,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Liefering",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.017419083439073,
+    47.820484578883416,
+    13.017419083439073,
+    47.820484578883416
+],
+  "geometry": {"coordinates":[13.01741908343907,47.82048457888342],"type":"Point"}
+}

--- a/data/144/483/239/5/1444832395.geojson
+++ b/data/144/483/239/5/1444832395.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"062d150b38fc9c48d5bd52f79f394125",
-    "wof:hierarchy":[],
+    "wof:geomhash":"939a236e22bc5f44ec8cb5bd136e3ac9",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832395,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832395,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341017,
     "wof:name":"Salzachsee",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.015015822952526,
+    13.01501582295253,
     47.83427589336299,
-    13.015015822952526,
+    13.01501582295253,
     47.83427589336299
 ],
   "geometry": {"coordinates":[13.01501582295253,47.83427589336299],"type":"Point"}

--- a/data/144/483/239/5/1444832395.geojson
+++ b/data/144/483/239/5/1444832395.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832395,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.015015823,47.8342758934,13.015015823,47.8342758934",
+    "geom:latitude":47.834276,
+    "geom:longitude":13.015016,
+    "iso:country":"AT",
+    "lbl:latitude":47.834276,
+    "lbl:longitude":13.015016,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Salzachsee"
+    ],
+    "name:eng_x_preferred":[
+        "Salzachsee"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"062d150b38fc9c48d5bd52f79f394125",
+    "wof:hierarchy":[],
+    "wof:id":1444832395,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Salzachsee",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.015015822952526,
+    47.83427589336299,
+    13.015015822952526,
+    47.83427589336299
+],
+  "geometry": {"coordinates":[13.01501582295253,47.83427589336299],"type":"Point"}
+}

--- a/data/144/483/240/7/1444832407.geojson
+++ b/data/144/483/240/7/1444832407.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837115,
+        85632785,
+        101754151,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"f5c0cdff0c315a749ab814fc2b67c5e2",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f440f1d8e6899a59c84a5fd9736673b8",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837115,
+            "locality_id":101754151,
+            "neighbourhood_id":1444832407,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832407,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341018,
     "wof:name":"Itzling Nord",
-    "wof:parent_id":-1,
+    "wof:parent_id":101754151,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.021939501973298,
+    13.0219395019733,
     47.83777115975836,
-    13.021939501973298,
+    13.0219395019733,
     47.83777115975836
 ],
   "geometry": {"coordinates":[13.0219395019733,47.83777115975836],"type":"Point"}

--- a/data/144/483/240/7/1444832407.geojson
+++ b/data/144/483/240/7/1444832407.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832407,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.021939502,47.8377711598,13.021939502,47.8377711598",
+    "geom:latitude":47.837771,
+    "geom:longitude":13.02194,
+    "iso:country":"AT",
+    "lbl:latitude":47.837771,
+    "lbl:longitude":13.02194,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Itzling Nord"
+    ],
+    "name:eng_x_preferred":[
+        "Itzling Nord"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"f5c0cdff0c315a749ab814fc2b67c5e2",
+    "wof:hierarchy":[],
+    "wof:id":1444832407,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Itzling Nord",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.021939501973298,
+    47.83777115975836,
+    13.021939501973298,
+    47.83777115975836
+],
+  "geometry": {"coordinates":[13.0219395019733,47.83777115975836],"type":"Point"}
+}

--- a/data/144/483/241/9/1444832419.geojson
+++ b/data/144/483/241/9/1444832419.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832419,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0621368946,47.8357354838,13.0621368946,47.8357354838",
+    "geom:latitude":47.835735,
+    "geom:longitude":13.062137,
+    "iso:country":"AT",
+    "lbl:latitude":47.835735,
+    "lbl:longitude":13.062137,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Kasern"
+    ],
+    "name:eng_x_preferred":[
+        "Kasern"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"699681e1b3d25653bef1614ec8676364",
+    "wof:hierarchy":[],
+    "wof:id":1444832419,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Kasern",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.062136894635225,
+    47.83573548378626,
+    13.062136894635225,
+    47.83573548378626
+],
+  "geometry": {"coordinates":[13.06213689463523,47.83573548378626],"type":"Point"}
+}

--- a/data/144/483/241/9/1444832419.geojson
+++ b/data/144/483/241/9/1444832419.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"699681e1b3d25653bef1614ec8676364",
-    "wof:hierarchy":[],
+    "wof:geomhash":"93225cf5482c8db6182ab879dec092eb",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832419,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832419,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341021,
     "wof:name":"Kasern",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.062136894635225,
+    13.06213689463523,
     47.83573548378626,
-    13.062136894635225,
+    13.06213689463523,
     47.83573548378626
 ],
   "geometry": {"coordinates":[13.06213689463523,47.83573548378626],"type":"Point"}

--- a/data/144/483/242/9/1444832429.geojson
+++ b/data/144/483/242/9/1444832429.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832429,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0680878254,47.8173723826,13.0680878254,47.8173723826",
+    "geom:latitude":47.817372,
+    "geom:longitude":13.068088,
+    "iso:country":"AT",
+    "lbl:latitude":47.817372,
+    "lbl:longitude":13.068088,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Gnigl"
+    ],
+    "name:eng_x_preferred":[
+        "Gnigl"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"deed5a12182d7c15c5c6fb0c89e6edcb",
+    "wof:hierarchy":[],
+    "wof:id":1444832429,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Gnigl",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.068087825363824,
+    47.81737238261291,
+    13.068087825363824,
+    47.81737238261291
+],
+  "geometry": {"coordinates":[13.06808782536382,47.81737238261291],"type":"Point"}
+}

--- a/data/144/483/242/9/1444832429.geojson
+++ b/data/144/483/242/9/1444832429.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"deed5a12182d7c15c5c6fb0c89e6edcb",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c60bfb3f3b8baf12a8114df9008f1e0d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832429,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832429,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341022,
     "wof:name":"Gnigl",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.068087825363824,
+    13.06808782536382,
     47.81737238261291,
-    13.068087825363824,
+    13.06808782536382,
     47.81737238261291
 ],
   "geometry": {"coordinates":[13.06808782536382,47.81737238261291],"type":"Point"}

--- a/data/144/483/244/1/1444832441.geojson
+++ b/data/144/483/244/1/1444832441.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832441,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0782730722,47.8177566144,13.0782730722,47.8177566144",
+    "geom:latitude":47.817757,
+    "geom:longitude":13.078273,
+    "iso:country":"AT",
+    "lbl:latitude":47.817757,
+    "lbl:longitude":13.078273,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Heuberg"
+    ],
+    "name:eng_x_preferred":[
+        "Heuberg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"41a865dffb4b0a05ce00b7e7516f2c98",
+    "wof:hierarchy":[],
+    "wof:id":1444832441,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Heuberg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.07827307218777,
+    47.817756614444924,
+    13.07827307218777,
+    47.817756614444924
+],
+  "geometry": {"coordinates":[13.07827307218777,47.81775661444492],"type":"Point"}
+}

--- a/data/144/483/244/1/1444832441.geojson
+++ b/data/144/483/244/1/1444832441.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"41a865dffb4b0a05ce00b7e7516f2c98",
-    "wof:hierarchy":[],
+    "wof:geomhash":"239da97fc9f4c58e310c0e571aa834eb",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832441,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832441,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341022,
     "wof:name":"Heuberg",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -46,9 +63,9 @@
 },
   "bbox": [
     13.07827307218777,
-    47.817756614444924,
+    47.81775661444492,
     13.07827307218777,
-    47.817756614444924
+    47.81775661444492
 ],
   "geometry": {"coordinates":[13.07827307218777,47.81775661444492],"type":"Point"}
 }

--- a/data/144/483/245/3/1444832453.geojson
+++ b/data/144/483/245/3/1444832453.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832453,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0701477629,47.759166877,13.0701477629,47.759166877",
+    "geom:latitude":47.759167,
+    "geom:longitude":13.070148,
+    "iso:country":"AT",
+    "lbl:latitude":47.759167,
+    "lbl:longitude":13.070148,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Heilbrunn"
+    ],
+    "name:eng_x_preferred":[
+        "Heilbrunn"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"77a3f582e14f81aa4525a55a2cfb5f3f",
+    "wof:hierarchy":[],
+    "wof:id":1444832453,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Heilbrunn",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.070147762923721,
+    47.75916687700946,
+    13.070147762923721,
+    47.75916687700946
+],
+  "geometry": {"coordinates":[13.07014776292372,47.75916687700946],"type":"Point"}
+}

--- a/data/144/483/245/3/1444832453.geojson
+++ b/data/144/483/245/3/1444832453.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"77a3f582e14f81aa4525a55a2cfb5f3f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a474b222020b63dc80a1acb3a552e95e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444832453,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832453,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341023,
     "wof:name":"Heilbrunn",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.070147762923721,
+    13.07014776292372,
     47.75916687700946,
-    13.070147762923721,
+    13.07014776292372,
     47.75916687700946
 ],
   "geometry": {"coordinates":[13.07014776292372,47.75916687700946],"type":"Point"}

--- a/data/144/483/246/3/1444832463.geojson
+++ b/data/144/483/246/3/1444832463.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"cbc941da7e3391ce99c9f8bc4bec4737",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832463,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832463,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341026,
     "wof:name":"Josefiau",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],

--- a/data/144/483/246/3/1444832463.geojson
+++ b/data/144/483/246/3/1444832463.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832463,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0699761015,47.7858749191,13.0699761015,47.7858749191",
+    "geom:latitude":47.785875,
+    "geom:longitude":13.069976,
+    "iso:country":"AT",
+    "lbl:latitude":47.785875,
+    "lbl:longitude":13.069976,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Josefiau"
+    ],
+    "name:eng_x_preferred":[
+        "Josefiau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"cbc941da7e3391ce99c9f8bc4bec4737",
+    "wof:hierarchy":[],
+    "wof:id":1444832463,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Josefiau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.0699761014604,
+    47.78587491907177,
+    13.0699761014604,
+    47.78587491907177
+],
+  "geometry": {"coordinates":[13.0699761014604,47.78587491907177],"type":"Point"}
+}

--- a/data/144/483/247/5/1444832475.geojson
+++ b/data/144/483/247/5/1444832475.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"1c2ac28f52eed6499c38d0be20d7d2a0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1037d4a73a4c1d7b6ff719a4e0b97ed1",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832475,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832475,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341027,
     "wof:name":"Herrgau",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.063624627317374,
-    47.785413557478954,
-    13.063624627317374,
-    47.785413557478954
+    13.06362462731737,
+    47.78541355747895,
+    13.06362462731737,
+    47.78541355747895
 ],
   "geometry": {"coordinates":[13.06362462731737,47.78541355747895],"type":"Point"}
 }

--- a/data/144/483/247/5/1444832475.geojson
+++ b/data/144/483/247/5/1444832475.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832475,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0636246273,47.7854135575,13.0636246273,47.7854135575",
+    "geom:latitude":47.785414,
+    "geom:longitude":13.063625,
+    "iso:country":"AT",
+    "lbl:latitude":47.785413,
+    "lbl:longitude":13.063625,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Herrgau"
+    ],
+    "name:eng_x_preferred":[
+        "Herrgau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"1c2ac28f52eed6499c38d0be20d7d2a0",
+    "wof:hierarchy":[],
+    "wof:id":1444832475,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Herrgau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.063624627317374,
+    47.785413557478954,
+    13.063624627317374,
+    47.785413557478954
+],
+  "geometry": {"coordinates":[13.06362462731737,47.78541355747895],"type":"Point"}
+}

--- a/data/144/483/248/5/1444832485.geojson
+++ b/data/144/483/248/5/1444832485.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832485,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0700333219,47.7774159725,13.0700333219,47.7774159725",
+    "geom:latitude":47.777416,
+    "geom:longitude":13.070033,
+    "iso:country":"AT",
+    "lbl:latitude":47.777416,
+    "lbl:longitude":13.070033,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Alpensiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Alpensiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"ac8e700a224c353608de08939f3f29ad",
+    "wof:hierarchy":[],
+    "wof:id":1444832485,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Alpensiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.070033321948173,
+    47.7774159725433,
+    13.070033321948173,
+    47.7774159725433
+],
+  "geometry": {"coordinates":[13.07003332194817,47.7774159725433],"type":"Point"}
+}

--- a/data/144/483/248/5/1444832485.geojson
+++ b/data/144/483/248/5/1444832485.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"ac8e700a224c353608de08939f3f29ad",
-    "wof:hierarchy":[],
+    "wof:geomhash":"cc7928223cf6bc74f2e67fc8dc08dc63",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832485,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832485,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341027,
     "wof:name":"Alpensiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.070033321948173,
+    13.07003332194817,
     47.7774159725433,
-    13.070033321948173,
+    13.07003332194817,
     47.7774159725433
 ],
   "geometry": {"coordinates":[13.07003332194817,47.7774159725433],"type":"Point"}

--- a/data/144/483/249/7/1444832497.geojson
+++ b/data/144/483/249/7/1444832497.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"0fe7de094cbc52b879e067d740cebc64",
-    "wof:hierarchy":[],
+    "wof:geomhash":"417cc1660861c79871084e06ce219c6a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832497,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832497,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341028,
     "wof:name":"Kleingmain",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.053553821468979,
+    13.05355382146898,
     47.78472150928844,
-    13.053553821468979,
+    13.05355382146898,
     47.78472150928844
 ],
   "geometry": {"coordinates":[13.05355382146898,47.78472150928844],"type":"Point"}

--- a/data/144/483/249/7/1444832497.geojson
+++ b/data/144/483/249/7/1444832497.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832497,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0535538215,47.7847215093,13.0535538215,47.7847215093",
+    "geom:latitude":47.784722,
+    "geom:longitude":13.053554,
+    "iso:country":"AT",
+    "lbl:latitude":47.784722,
+    "lbl:longitude":13.053554,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Kleingmain"
+    ],
+    "name:eng_x_preferred":[
+        "Kleingmain"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"0fe7de094cbc52b879e067d740cebc64",
+    "wof:hierarchy":[],
+    "wof:id":1444832497,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Kleingmain",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.053553821468979,
+    47.78472150928844,
+    13.053553821468979,
+    47.78472150928844
+],
+  "geometry": {"coordinates":[13.05355382146898,47.78472150928844],"type":"Point"}
+}

--- a/data/144/483/250/9/1444832509.geojson
+++ b/data/144/483/250/9/1444832509.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832509,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0377451878,47.7660150832,13.0377451878,47.7660150832",
+    "geom:latitude":47.766015,
+    "geom:longitude":13.037745,
+    "iso:country":"AT",
+    "lbl:latitude":47.766015,
+    "lbl:longitude":13.037745,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Eichethofsiedlung"
+    ],
+    "name:eng_x_preferred":[
+        "Eichethofsiedlung"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"51d49cc594a60ea9bbcf09f377ee4f48",
+    "wof:hierarchy":[],
+    "wof:id":1444832509,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Eichethofsiedlung",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.037745187750586,
+    47.76601508318812,
+    13.037745187750586,
+    47.76601508318812
+],
+  "geometry": {"coordinates":[13.03774518775059,47.76601508318812],"type":"Point"}
+}

--- a/data/144/483/250/9/1444832509.geojson
+++ b/data/144/483/250/9/1444832509.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"51d49cc594a60ea9bbcf09f377ee4f48",
-    "wof:hierarchy":[],
+    "wof:geomhash":"0c9b1e8e1c34925ce928ffd847156ddf",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832509,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832509,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341031,
     "wof:name":"Eichethofsiedlung",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.037745187750586,
+    13.03774518775059,
     47.76601508318812,
-    13.037745187750586,
+    13.03774518775059,
     47.76601508318812
 ],
   "geometry": {"coordinates":[13.03774518775059,47.76601508318812],"type":"Point"}

--- a/data/144/483/251/9/1444832519.geojson
+++ b/data/144/483/251/9/1444832519.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832519,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0338541946,47.7609956393,13.0338541946,47.7609956393",
+    "geom:latitude":47.760996,
+    "geom:longitude":13.033854,
+    "iso:country":"AT",
+    "lbl:latitude":47.760996,
+    "lbl:longitude":13.033854,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Birkensiedling"
+    ],
+    "name:eng_x_preferred":[
+        "Birkensiedling"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"05860d9e1e61530a91504df4cb517d3c",
+    "wof:hierarchy":[],
+    "wof:id":1444832519,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Birkensiedling",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.03385419458189,
+    47.7609956392685,
+    13.03385419458189,
+    47.7609956392685
+],
+  "geometry": {"coordinates":[13.03385419458189,47.7609956392685],"type":"Point"}
+}

--- a/data/144/483/251/9/1444832519.geojson
+++ b/data/144/483/251/9/1444832519.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
     "wof:geomhash":"05860d9e1e61530a91504df4cb517d3c",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444832519,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832519,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341032,
     "wof:name":"Birkensiedling",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/144/483/253/1/1444832531.geojson
+++ b/data/144/483/253/1/1444832531.geojson
@@ -29,13 +29,29 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        1108837079,
+        85632785,
+        102049779,
+        85681681
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"fde0a5318a040a42cf8bb9b54f234693",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2c42cd069411247a91a23a84bec619ed",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049779,
+            "localadmin_id":1108837079,
+            "locality_id":-1,
+            "neighbourhood_id":1444832531,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832531,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341032,
     "wof:name":"Obermoos",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.015143095079473,
+    13.01514309507947,
     47.75661044132905,
-    13.015143095079473,
+    13.01514309507947,
     47.75661044132905
 ],
   "geometry": {"coordinates":[13.01514309507947,47.75661044132905],"type":"Point"}

--- a/data/144/483/253/1/1444832531.geojson
+++ b/data/144/483/253/1/1444832531.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832531,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0151430951,47.7566104413,13.0151430951,47.7566104413",
+    "geom:latitude":47.75661,
+    "geom:longitude":13.015143,
+    "iso:country":"AT",
+    "lbl:latitude":47.75661,
+    "lbl:longitude":13.015143,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Obermoos"
+    ],
+    "name:eng_x_preferred":[
+        "Obermoos"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"fde0a5318a040a42cf8bb9b54f234693",
+    "wof:hierarchy":[],
+    "wof:id":1444832531,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Obermoos",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.015143095079473,
+    47.75661044132905,
+    13.015143095079473,
+    47.75661044132905
+],
+  "geometry": {"coordinates":[13.01514309507947,47.75661044132905],"type":"Point"}
+}

--- a/data/144/483/254/3/1444832543.geojson
+++ b/data/144/483/254/3/1444832543.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444832543,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"13.0242983731,47.7806091047,13.0242983731,47.7806091047",
+    "geom:latitude":47.780609,
+    "geom:longitude":13.024298,
+    "iso:country":"AT",
+    "lbl:latitude":47.780609,
+    "lbl:longitude":13.024298,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:deu_x_preferred":[
+        "Untermoos"
+    ],
+    "name:eng_x_preferred":[
+        "Untermoos"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"AT",
+    "wof:geomhash":"2404837554fd8850da0e357c99075173",
+    "wof:hierarchy":[],
+    "wof:id":1444832543,
+    "wof:lastmodified":1566333181,
+    "wof:name":"Untermoos",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-at",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    13.024298373123468,
+    47.78060910474697,
+    13.024298373123468,
+    47.78060910474697
+],
+  "geometry": {"coordinates":[13.02429837312347,47.78060910474697],"type":"Point"}
+}

--- a/data/144/483/254/3/1444832543.geojson
+++ b/data/144/483/254/3/1444832543.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        85681681,
+        102191581,
+        1108837189,
+        85632785,
+        1175610443,
+        102049799
+    ],
     "wof:breaches":[],
     "wof:country":"AT",
-    "wof:geomhash":"2404837554fd8850da0e357c99075173",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6e0995a632dbd019f1501edab0cfff8a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85632785,
+            "county_id":102049799,
+            "localadmin_id":1108837189,
+            "locality_id":1175610443,
+            "neighbourhood_id":1444832543,
+            "region_id":85681681
+        }
+    ],
     "wof:id":1444832543,
-    "wof:lastmodified":1566333181,
+    "wof:lastmodified":1566341033,
     "wof:name":"Untermoos",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175610443,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-at",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    13.024298373123468,
+    13.02429837312347,
     47.78060910474697,
-    13.024298373123468,
+    13.02429837312347,
     47.78060910474697
 ],
   "geometry": {"coordinates":[13.02429837312347,47.78060910474697],"type":"Point"}


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1695.

This PR contains new neighbourhood records from Nat's neighbourhood import file. 