### PR TITLE
Updated name translations for Nitzing, AT

### DIFF
--- a/data/112/604/900/1/1126049001.geojson
+++ b/data/112/604/900/1/1126049001.geojson
@@ -31,6 +31,12 @@
     "name:deu_x_preferred":[
         "Nitzing"
     ],
+    "name:eng_x_preferred":[
+        "Nitzing"
+    ],
+    "name:eng_x_variant":[
+        "Ritzing"
+    ],
     "name:epo_x_preferred":[
         "Nitzing"
     ],
@@ -121,10 +127,8 @@
         }
     ],
     "wof:id":1126049001,
-    "wof:lastmodified":1566599295,
+    "wof:lastmodified":1574295919,
     "wof:name":"Nitzing",
-    "name:eng_x_preferred":["Nitzing"],
-    "name:eng_x_variant":["Ritzing"],
     "wof:parent_id":1108836869,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-at",

--- a/data/112/604/900/1/1126049001.geojson
+++ b/data/112/604/900/1/1126049001.geojson
@@ -23,73 +23,52 @@
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:ceb_x_preferred":[
-        "Ritzing"
+        "Nitzing"
     ],
     "name:ces_x_preferred":[
-        "Ritzing"
+        "Nitzing"
     ],
     "name:deu_x_preferred":[
-        "Ritzing"
+        "Nitzing"
     ],
     "name:epo_x_preferred":[
-        "Ritzing"
-    ],
-    "name:fas_x_preferred":[
-        "\u0631\u06cc\u062a\u0633\u06cc\u0646\u06af"
+        "Nitzing"
     ],
     "name:fra_x_preferred":[
-        "Ritzing"
-    ],
-    "name:hrv_x_preferred":[
-        "Ricinja"
-    ],
-    "name:hun_x_preferred":[
-        "R\u00e9c\u00e9ny"
+        "Nitzing"
     ],
     "name:ita_x_preferred":[
-        "Ritzing"
-    ],
-    "name:kaz_x_preferred":[
-        "\u0420\u0438\u0442\u0446\u0438\u043d\u0433"
+        "Nitzing"
     ],
     "name:nld_x_preferred":[
-        "Ritzing"
+        "Nitzing"
     ],
     "name:pol_x_preferred":[
-        "Ritzing"
+        "Nitzing"
     ],
     "name:por_x_preferred":[
-        "Ritzing"
-    ],
-    "name:rus_x_preferred":[
-        "\u0420\u0438\u0442\u0446\u0438\u043d\u0433"
+        "Nitzing"
     ],
     "name:slk_x_preferred":[
-        "Ritzing"
+        "Nitzing"
     ],
     "name:spa_x_preferred":[
-        "Ritzing"
+        "Nitzing"
     ],
     "name:swe_x_preferred":[
-        "Ritzing"
+        "Nitzing"
     ],
     "name:tur_x_preferred":[
-        "Ritzing"
-    ],
-    "name:ukr_x_preferred":[
-        "\u0420\u0456\u0442\u0446\u0438\u043d\u0433"
+        "Nitzing"
     ],
     "name:uzb_x_preferred":[
-        "Ritzing"
+        "Nitzing"
     ],
     "name:vol_x_preferred":[
-        "Ritzing"
+        "Nitzing"
     ],
     "name:war_x_preferred":[
-        "Ritzing"
-    ],
-    "name:zho_x_preferred":[
-        "\u91cc\u7279\u8d5e"
+        "Nitzing"
     ],
     "qs_pg:aaroncc":"AT",
     "qs_pg:gn_country":"AT",
@@ -143,7 +122,9 @@
     ],
     "wof:id":1126049001,
     "wof:lastmodified":1566599295,
-    "wof:name":"Ritzing",
+    "wof:name":"Nitzing",
+    "name:eng_x_preferred":["Nitzing"],
+    "name:eng_x_variant":["Ritzing"],
     "wof:parent_id":1108836869,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-at",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1743

Fixes names translations for Nitzing, Austria. 

No PIP work required, can merge once approved.