### PR TITLE
Name updates

### DIFF
--- a/data/856/327/85/85632785.geojson
+++ b/data/856/327/85/85632785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.033457,
-    "geom:area_square_m":83674200419.839432,
+    "geom:area_square_m":83674200347.191071,
     "geom:bbox":"9.529959,46.372299,17.160703,49.020336",
     "geom:latitude":47.586911,
     "geom:longitude":14.141446,
@@ -92,6 +92,9 @@
     ],
     "name:bam_x_preferred":[
         "Otirisi"
+    ],
+    "name:ban_x_preferred":[
+        "Austria"
     ],
     "name:bar_x_preferred":[
         "\u00d6stareich"
@@ -203,6 +206,12 @@
     "name:dan_x_preferred":[
         "\u00d8strig"
     ],
+    "name:deu_at_x_preferred":[
+        "\u00d6sterreich"
+    ],
+    "name:deu_ch_x_preferred":[
+        "\u00d6sterreich"
+    ],
     "name:deu_x_colloquial":[
         "Osterreich",
         "Republik Oesterreich",
@@ -234,6 +243,12 @@
     ],
     "name:eml_x_preferred":[
         "\u00c0ustria"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Austria"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Austria"
     ],
     "name:eng_x_preferred":[
         "Austria"
@@ -278,6 +293,9 @@
     "name:fas_x_variant":[
         "\u0627\u062a\u0631\u064a\u0634"
     ],
+    "name:fij_x_preferred":[
+        "Austria"
+    ],
     "name:fin_x_colloquial":[
         "Itaevalta",
         "Itavalta"
@@ -308,6 +326,9 @@
     ],
     "name:gag_x_preferred":[
         "Avstriya"
+    ],
+    "name:gcr_x_preferred":[
+        "Otrich"
     ],
     "name:gla_x_preferred":[
         "An Ostair"
@@ -456,6 +477,9 @@
     ],
     "name:kbp_x_preferred":[
         "Otirisi"
+    ],
+    "name:kea_x_preferred":[
+        "\u00c1ustria"
     ],
     "name:khm_x_preferred":[
         "\u17a2\u17bc\u1791\u17d2\u179a\u17b8\u179f"
@@ -745,6 +769,9 @@
     "name:pol_x_preferred":[
         "Austria"
     ],
+    "name:por_br_x_preferred":[
+        "\u00c1ustria"
+    ],
     "name:por_x_preferred":[
         "\u00c1ustria"
     ],
@@ -853,6 +880,12 @@
     "name:srn_x_preferred":[
         "Ostriyakondre"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0410\u0443\u0441\u0442\u0440\u0438\u0458\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Austrija"
+    ],
     "name:srp_x_preferred":[
         "\u0410\u0443\u0441\u0442\u0440\u0438\u0458\u0430"
     ],
@@ -877,6 +910,9 @@
     ],
     "name:szl_x_preferred":[
         "Austrijo"
+    ],
+    "name:szy_x_preferred":[
+        "Austria"
     ],
     "name:tah_x_preferred":[
         "Auteteria"
@@ -1019,8 +1055,26 @@
     "name:zha_x_preferred":[
         "Audeihleih"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5965\u5730\u5229"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5967\u5730\u5229"
+    ],
     "name:zho_min_nan_x_preferred":[
         "\u00d2-t\u0113-l\u012b"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u5967\u5730\u5229"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u5965\u5730\u5229"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u5965\u5730\u5229"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5967\u5730\u5229"
     ],
     "name:zho_x_preferred":[
         "\u5965\u5730\u5229"
@@ -1190,7 +1244,7 @@
         "slv",
         "hun"
     ],
-    "wof:lastmodified":1583797279,
+    "wof:lastmodified":1587427831,
     "wof:name":"Austria",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.