### PR TITLE
Update Austria admin1 labels, names, concordances

### DIFF
--- a/data/856/816/49/85681649.geojson
+++ b/data/856/816/49/85681649.geojson
@@ -10,14 +10,23 @@
     "geom:latitude":47.2385,
     "geom:longitude":9.896785,
     "iso:country":"AT",
+    "label:deu_x_preferred_longname":[
+        "Vorarlberg"
+    ],
+    "label:deu_x_preferred_placetype":[
+        "l\u00e4nder"
+    ],
+    "label:deu_x_preferred_shortcode":[
+        "VO"
+    ],
     "label:eng_x_preferred_longname":[
         "Vorarlberg State"
     ],
     "label:eng_x_preferred_placetype":[
         "state"
     ],
-    "label:eng_x_preferred_shortcode":[
-        "VO"
+    "label:eng_x_variant_longname":[
+        "State of Vorarlberg"
     ],
     "lbl:latitude":47.254268,
     "lbl:longitude":9.891515,
@@ -439,7 +448,8 @@
         "hasc:id":"AT.VO",
         "iso:id":"AT-8",
         "unlc:id":"AT-8",
-        "wd:id":"Q38981"
+        "wd:id":"Q38981",
+        "wk:page":"Vorarlberg"
     },
     "wof:country":"AT",
     "wof:geom_alt":[
@@ -463,7 +473,7 @@
         "slv",
         "hun"
     ],
-    "wof:lastmodified":1583882652,
+    "wof:lastmodified":1623097159,
     "wof:name":"Vorarlberg",
     "wof:parent_id":85632785,
     "wof:placetype":"region",

--- a/data/856/816/51/85681651.geojson
+++ b/data/856/816/51/85681651.geojson
@@ -13,14 +13,23 @@
     "geom:latitude":47.543481,
     "geom:longitude":16.522756,
     "iso:country":"AT",
+    "label:deu_x_preferred_longname":[
+        "Burgenland"
+    ],
+    "label:deu_x_preferred_placetype":[
+        "l\u00e4nder"
+    ],
+    "label:deu_x_preferred_shortcode":[
+        "BU"
+    ],
     "label:eng_x_preferred_longname":[
         "Burgenland State"
     ],
     "label:eng_x_preferred_placetype":[
         "state"
     ],
-    "label:eng_x_preferred_shortcode":[
-        "BU"
+    "label:eng_x_variant_longname":[
+        "State of Burgenland"
     ],
     "lbl:latitude":47.26185,
     "lbl:longitude":16.271512,
@@ -433,7 +442,8 @@
         "hasc:id":"AT.BU",
         "iso:id":"AT-1",
         "unlc:id":"AT-1",
-        "wd:id":"Q43210"
+        "wd:id":"Q43210",
+        "wk:page":"Burgenland"
     },
     "wof:country":"AT",
     "wof:geom_alt":[
@@ -457,7 +467,7 @@
         "slv",
         "hun"
     ],
-    "wof:lastmodified":1583882640,
+    "wof:lastmodified":1623097095,
     "wof:name":"Burgenland",
     "wof:parent_id":85632785,
     "wof:placetype":"region",

--- a/data/856/816/55/85681655.geojson
+++ b/data/856/816/55/85681655.geojson
@@ -10,14 +10,23 @@
     "geom:latitude":46.773915,
     "geom:longitude":13.917563,
     "iso:country":"AT",
+    "label:deu_x_preferred_longname":[
+        "K\u00e4rnten"
+    ],
+    "label:deu_x_preferred_placetype":[
+        "l\u00e4nder"
+    ],
+    "label:deu_x_preferred_shortcode":[
+        "KA"
+    ],
     "label:eng_x_preferred_longname":[
-        "K\u00e4rnten State"
+        "Carinthia State"
     ],
     "label:eng_x_preferred_placetype":[
         "state"
     ],
-    "label:eng_x_preferred_shortcode":[
-        "KA"
+    "label:eng_x_variant_longname":[
+        "State of Carinthia"
     ],
     "lbl:latitude":46.751447,
     "lbl:longitude":14.180591,
@@ -429,7 +438,8 @@
         "hasc:id":"AT.KA",
         "iso:id":"AT-2",
         "unlc:id":"AT-2",
-        "wd:id":"Q37985"
+        "wd:id":"Q37985",
+        "wk:page":"Carinthia"
     },
     "wof:country":"AT",
     "wof:geom_alt":[
@@ -453,7 +463,7 @@
         "slv",
         "hun"
     ],
-    "wof:lastmodified":1583882641,
+    "wof:lastmodified":1623097100,
     "wof:name":"K\u00e4rnten",
     "wof:parent_id":85632785,
     "wof:placetype":"region",

--- a/data/856/816/61/85681661.geojson
+++ b/data/856/816/61/85681661.geojson
@@ -10,14 +10,23 @@
     "geom:latitude":47.194665,
     "geom:longitude":11.50173,
     "iso:country":"AT",
+    "label:deu_x_preferred_longname":[
+        "Tirol"
+    ],
+    "label:deu_x_preferred_placetype":[
+        "l\u00e4nder"
+    ],
+    "label:deu_x_preferred_shortcode":[
+        "TR"
+    ],
     "label:eng_x_preferred_longname":[
-        "Tirol State"
+        "Tyrol State"
     ],
     "label:eng_x_preferred_placetype":[
         "state"
     ],
-    "label:eng_x_preferred_shortcode":[
-        "TR"
+    "label:eng_x_variant_longname":[
+        "State of Tyrol"
     ],
     "lbl:latitude":47.123291,
     "lbl:longitude":10.876187,
@@ -83,10 +92,10 @@
         "\u03a4\u03b9\u03c1\u03cc\u03bb\u03bf"
     ],
     "name:eng_x_preferred":[
-        "Tirol"
+        "Tyrol"
     ],
     "name:eng_x_variant":[
-        "Tyrol"
+        "Tirol"
     ],
     "name:epo_x_preferred":[
         "Tirolo"
@@ -420,7 +429,8 @@
         "hasc:id":"AT.TR",
         "iso:id":"AT-7",
         "unlc:id":"AT-7",
-        "wd:id":"Q42880"
+        "wd:id":"Q42880",
+        "wk:page":"Tyrol_(state)"
     },
     "wof:country":"AT",
     "wof:geom_alt":[
@@ -444,7 +454,7 @@
         "slv",
         "hun"
     ],
-    "wof:lastmodified":1583882650,
+    "wof:lastmodified":1623097125,
     "wof:name":"Tirol",
     "wof:parent_id":85632785,
     "wof:placetype":"region",

--- a/data/856/816/67/85681667.geojson
+++ b/data/856/816/67/85681667.geojson
@@ -10,14 +10,24 @@
     "geom:latitude":48.208443,
     "geom:longitude":16.377844,
     "iso:country":"AT",
+    "label:deu_x_preferred_longname":[
+        "Wien"
+    ],
+    "label:deu_x_preferred_placetype":[
+        "l\u00e4nder"
+    ],
+    "label:deu_x_preferred_shortcode":[
+        "WI"
+    ],
     "label:eng_x_preferred_longname":[
-        "Wien State"
+        "Vienna"
     ],
     "label:eng_x_preferred_placetype":[
         "state"
     ],
-    "label:eng_x_preferred_shortcode":[
-        "WI"
+    "label:eng_x_variant_longname":[
+        "State of Vienna",
+        "Vienna State"
     ],
     "lbl:latitude":48.202846,
     "lbl:longitude":16.381603,
@@ -170,10 +180,10 @@
         "\u0392\u03b9\u03ad\u03bd\u03bd\u03b7"
     ],
     "name:eng_x_preferred":[
-        "Wien"
+        "Vienna"
     ],
     "name:eng_x_variant":[
-        "Vienna"
+        "Wien"
     ],
     "name:epo_x_preferred":[
         "Vieno"
@@ -771,7 +781,8 @@
         "hasc:id":"AT.WI",
         "iso:id":"AT-9",
         "unlc:id":"AT-9",
-        "wd:id":"Q1741"
+        "wd:id":"Q1741",
+        "wk:page":"Vienna"
     },
     "wof:coterminous":[
         101748073,
@@ -799,7 +810,7 @@
         "slv",
         "hun"
     ],
-    "wof:lastmodified":1607996894,
+    "wof:lastmodified":1623097156,
     "wof:name":"Wien",
     "wof:parent_id":85632785,
     "wof:placetype":"region",

--- a/data/856/816/71/85681671.geojson
+++ b/data/856/816/71/85681671.geojson
@@ -10,14 +10,23 @@
     "geom:latitude":48.272132,
     "geom:longitude":15.751646,
     "iso:country":"AT",
+    "label:deu_x_preferred_longname":[
+        "Nieder\u00f6sterreich"
+    ],
+    "label:deu_x_preferred_placetype":[
+        "l\u00e4nder"
+    ],
+    "label:deu_x_preferred_shortcode":[
+        "NO"
+    ],
     "label:eng_x_preferred_longname":[
-        "Nieder\u00f6sterreich State"
+        "Lower Austria State"
     ],
     "label:eng_x_preferred_placetype":[
         "state"
     ],
-    "label:eng_x_preferred_shortcode":[
-        "NO"
+    "label:eng_x_variant_longname":[
+        "State of Lower Austria"
     ],
     "lbl:latitude":48.305564,
     "lbl:longitude":15.636522,
@@ -439,7 +448,8 @@
         "hasc:id":"AT.NO",
         "iso:id":"AT-3",
         "unlc:id":"AT-3",
-        "wd:id":"Q42497"
+        "wd:id":"Q42497",
+        "wk:page":"Lower_Austria"
     },
     "wof:country":"AT",
     "wof:geom_alt":[
@@ -463,7 +473,7 @@
         "slv",
         "hun"
     ],
-    "wof:lastmodified":1583882643,
+    "wof:lastmodified":1623097105,
     "wof:name":"Nieder\u00f6sterreich",
     "wof:parent_id":85632785,
     "wof:placetype":"region",

--- a/data/856/816/77/85681677.geojson
+++ b/data/856/816/77/85681677.geojson
@@ -10,14 +10,23 @@
     "geom:latitude":48.137095,
     "geom:longitude":13.965282,
     "iso:country":"AT",
+    "label:deu_x_preferred_longname":[
+        "Ober\u00f6sterreich"
+    ],
+    "label:deu_x_preferred_placetype":[
+        "l\u00e4nder"
+    ],
+    "label:deu_x_preferred_shortcode":[
+        "OO"
+    ],
     "label:eng_x_preferred_longname":[
-        "Ober\u00f6sterreich State"
+        "Upper Austria State"
     ],
     "label:eng_x_preferred_placetype":[
         "state"
     ],
-    "label:eng_x_preferred_shortcode":[
-        "OO"
+    "label:eng_x_variant_longname":[
+        "State of Upper Austria"
     ],
     "lbl:latitude":48.152911,
     "lbl:longitude":13.982183,
@@ -417,7 +426,8 @@
         "hasc:id":"AT.OO",
         "iso:id":"AT-4",
         "unlc:id":"AT-4",
-        "wd:id":"Q41967"
+        "wd:id":"Q41967",
+        "wk:page":"Upper_Austria"
     },
     "wof:country":"AT",
     "wof:geom_alt":[
@@ -441,7 +451,7 @@
         "slv",
         "hun"
     ],
-    "wof:lastmodified":1617130365,
+    "wof:lastmodified":1623097110,
     "wof:name":"Ober\u00f6sterreich",
     "wof:parent_id":85632785,
     "wof:placetype":"region",

--- a/data/856/816/81/85681681.geojson
+++ b/data/856/816/81/85681681.geojson
@@ -10,14 +10,23 @@
     "geom:latitude":47.38854,
     "geom:longitude":13.084288,
     "iso:country":"AT",
+    "label:deu_x_preferred_longname":[
+        "Salzburg"
+    ],
+    "label:deu_x_preferred_placetype":[
+        "l\u00e4nder"
+    ],
+    "label:deu_x_preferred_shortcode":[
+        "SZ"
+    ],
     "label:eng_x_preferred_longname":[
         "Salzburg State"
     ],
     "label:eng_x_preferred_placetype":[
         "state"
     ],
-    "label:eng_x_preferred_shortcode":[
-        "SZ"
+    "label:eng_x_variant_longname":[
+        "State of Salzburg"
     ],
     "lbl:latitude":47.347177,
     "lbl:longitude":13.243764,
@@ -415,7 +424,8 @@
         "hasc:id":"AT.SZ",
         "iso:id":"AT-5",
         "unlc:id":"AT-5",
-        "wd:id":"Q43325"
+        "wd:id":"Q43325",
+        "wk:page":"Salzburg_(state)"
     },
     "wof:country":"AT",
     "wof:geom_alt":[
@@ -439,7 +449,7 @@
         "slv",
         "hun"
     ],
-    "wof:lastmodified":1583882647,
+    "wof:lastmodified":1623097114,
     "wof:name":"Salzburg",
     "wof:parent_id":85632785,
     "wof:placetype":"region",

--- a/data/856/816/87/85681687.geojson
+++ b/data/856/816/87/85681687.geojson
@@ -10,14 +10,23 @@
     "geom:latitude":47.2691,
     "geom:longitude":15.011878,
     "iso:country":"AT",
+    "label:deu_x_preferred_longname":[
+        "Steiermark"
+    ],
+    "label:deu_x_preferred_placetype":[
+        "l\u00e4nder"
+    ],
+    "label:deu_x_preferred_shortcode":[
+        "ST"
+    ],
     "label:eng_x_preferred_longname":[
-        "Steiermark State"
+        "Styria State"
     ],
     "label:eng_x_preferred_placetype":[
         "state"
     ],
-    "label:eng_x_preferred_shortcode":[
-        "ST"
+    "label:eng_x_variant_longname":[
+        "State of Styria"
     ],
     "lbl:latitude":47.216225,
     "lbl:longitude":15.427609,
@@ -74,10 +83,10 @@
         "\u03a3\u03c4\u03c5\u03c1\u03af\u03b1"
     ],
     "name:eng_x_preferred":[
-        "Steiermark"
+        "Styria"
     ],
     "name:eng_x_variant":[
-        "Styria"
+        "Steiermark"
     ],
     "name:epo_x_preferred":[
         "Stirio"
@@ -92,7 +101,7 @@
         "\u0627\u0634\u062a\u0627\u06cc\u0631\u0645\u0627\u0631\u06a9"
     ],
     "name:fil_x_preferred":[
-        "Steiermark Wappen.svg|55px"
+        "Steiermark Wappen"
     ],
     "name:fra_x_preferred":[
         "Styrie"
@@ -329,7 +338,9 @@
         "gp:id":2344713,
         "hasc:id":"AT.ST",
         "iso:id":"AT-6",
-        "unlc:id":"AT-6"
+        "unlc:id":"AT-6",
+        "wd:id":"Q41358",
+        "wk:page":"Styria"
     },
     "wof:country":"AT",
     "wof:geom_alt":[
@@ -353,7 +364,7 @@
         "slv",
         "hun"
     ],
-    "wof:lastmodified":1583882648,
+    "wof:lastmodified":1623097120,
     "wof:name":"Steiermark",
     "wof:parent_id":85632785,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1640

This PR:

- Corrects and adds `label:` properties in all region records in this repo
- Updates `deu` and `eng` names whenever required
- Adds `wk:page` and `wd:id` concordances to all region records in this repo

No PIP work required, can merge once approved.