### PR TITLE
Fixed label:deu_x_preferred_shortcode

### DIFF
--- a/data/856/816/77/85681677.geojson
+++ b/data/856/816/77/85681677.geojson
@@ -17,7 +17,7 @@
         "l\u00e4nder"
     ],
     "label:deu_x_preferred_shortcode":[
-        "OO"
+        "O\u00d6"
     ],
     "label:eng_x_preferred_longname":[
         "Upper Austria State"


### PR DESCRIPTION
Since the name is Oberösterreich the abbreviation is "OÖ" instead of "OO". Source: https://de.wikipedia.org/wiki/Ober%C3%B6sterreich