### PR TITLE
Fix label:deu_x_preferred_shortcode

### DIFF
--- a/data/856/816/77/85681677.geojson
+++ b/data/856/816/77/85681677.geojson
@@ -25,6 +25,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "OO"
+    ],
     "label:eng_x_variant_longname":[
         "State of Upper Austria"
     ],
@@ -451,7 +454,7 @@
         "slv",
         "hun"
     ],
-    "wof:lastmodified":1623097110,
+    "wof:lastmodified":1677266203,
     "wof:name":"Ober\u00f6sterreich",
     "wof:parent_id":85632785,
     "wof:placetype":"region",

--- a/data/856/816/77/85681677.geojson
+++ b/data/856/816/77/85681677.geojson
@@ -17,7 +17,7 @@
         "l\u00e4nder"
     ],
     "label:deu_x_preferred_shortcode":[
-        "OO"
+        "O\u00d6"
     ],
     "label:eng_x_preferred_longname":[
         "Upper Austria State"


### PR DESCRIPTION
This PR updates `label` properties for a region record in Austria. No PIP work required.